### PR TITLE
Refactored Rui, tests, and imports. Removed extra init in Rui.

### DIFF
--- a/src/ids_codes/Concept.py
+++ b/src/ids_codes/Concept.py
@@ -1,6 +1,6 @@
 class Concept:
-	
 	"""concept based system concept code"""
+	
 	def __init__(self, code, cs_rui, any_name=""):
 		self.code = code
 		self.cs_rui = cs_rui
@@ -8,8 +8,8 @@ class Concept:
 
 
 class Attribute:
-
 	"""concept based system attribute or relationship"""
+
 	def __init__(self, r, cs_rui, any_name=""):
 		self.r = r 
 		self.cs_rui = cs_rui

--- a/src/ids_codes/Rui.py
+++ b/src/ids_codes/Rui.py
@@ -1,40 +1,48 @@
 from uuid6 import uuid7, UUID
 from datetime import datetime, timezone
 import logging
+import enum
+
+
+"""Enum representing RUI statuses"""
+class RuiStatus(enum.Enum):
+	assigned = 'A'
+	reserved = 'R'
 
 class Rui:
-	"""Referent Unique Identifier"""
-	
-	def setAssignedOrReserved(self, a_or_r):
-		if (a_or_r == 'A' or a_or_r == 'R'):
-			self.a_or_r = a_or_r
-		else:
-			raise Exception("a_or_r must be set to A (assigned) or R (reserved)")
+	"""Referent Unique Identifier
 
-	def __init__(self, uuid, a_or_r):
+	Attributes:
+	uuid -- the unique identifier of the RUI
+	status -- The current status of the RUI
+	"""
+
+	def __init__(self, status: RuiStatus, uuid: UUID = uuid7()):
 		self.uuid = uuid
-		self.setAssignedOrReserved(a_or_r)
-
-	def __init__(self, a_or_r):
-		self.uuid = uuid7()
-		self.setAssignedOrReserved(a_or_r)
+		self.status = status
 
 	def is_assigned(self):
-		return (self.a_or_r == 'A')
+		return self.status is RuiStatus.assigned
 
 	def is_reserved(self): 
-		return (self.a_or_r == 'R')
+		return self.status is RuiStatus.reserved
 
 	def update_status_assigned(self):
-		if (self.a_or_r == 'A'):
+		if self.status is RuiStatus.assigned:
 			logging.warning("status of Rui instance is already assigned. No change.")
 		else:
-			self.a_or_r = 'A'
+			self.status = RuiStatus(RuiStatus.assigned)
+
+
+# class TempRefStatus(enum.Enum):
+# 	 = 'U'
+# 	 = 'C'
+# 	 = ''
 
 class TempRef:
 	"""Temporal Reference"""
 
-	def __init__(self, tr, ref_type = None):
+	def __init__(self, tr, ref_type:str=''):
 		if (isinstance(tr, datetime)):
 			if tr.tzinfo != timezone.utc:
 				tr = tr.astimezone(timezone.utc)
@@ -56,8 +64,8 @@ class TempRef:
 		else:
 			raise Exception("temporal reference must be datatime or uuid")
 
-	def isCalendar():
+	def isCalendar(self):
 		return (self.cal != None)
 
-	def isUuid():
+	def isUuid(self):
 		return (self.uuid != None)

--- a/src/rtt/atuple.py
+++ b/src/rtt/atuple.py
@@ -1,14 +1,12 @@
 from uuid6 import uuid7
 from datetime import datetime, timezone
-
-import sys
   
-from ids_codes import Rui
+from src.ids_codes.Rui import Rui, RuiStatus
 
 class RtTuple:
 	def __init__(self, ruit):
 		if ruit is None:
-			self.ruit = Rui.Rui('A')
+			self.ruit = Rui(RuiStatus.assigned)
 		else:	
 			self.ruit = ruit
 
@@ -20,21 +18,15 @@ class RtTuple:
 #	capture that. Depending on whether 
 class Atuple(RtTuple):
 	"""Referent Tracking assignment tuple that registers assignment of an RUI to a PoR"""
-	def __init__(self, ruip=None, ruia=None, ruit=None, unique=None, ar=None, t=None):
+	def __init__(self, ruip=Rui(RuiStatus.assigned), ruia=None, ruit=None, unique="-SU", ar=RuiStatus.assigned, t=datetime.now(timezone.utc)):
 		super().__init__(ruit)
 
 		# If we don't get a value for whether the Rui is assigned or reserved
 		#	then we assume that it is assigned
-		if ar is None:
-			self.ar = 'A'
-		else:
-			self.ar = ar
+		self.ar = ar
 
 		# If we don't get a Ruip, then we'll create one on the fly
-		if ruip is None: 
-			self.ruip = Rui.Rui(self.ar)
-		else:
-			self.ruip = ruip 
+		self.ruip = ruip 
 		
 		# If we don't get an author Rui for the tuple, then autogenerate one,
 		#	unless we don't get a Ruip either, in which case set it to the
@@ -42,27 +34,13 @@ class Atuple(RtTuple):
 		# This means that the default behavior is that if neither Ruia nor Ruip
 		#	are provided, we are assuming some entity is assigning a Ruip to 
 		#	itself, and thus should be equal
-		if ruia is None:
-			if ruip is None:
-				self.ruia = ruip
-			else:
-				self.ruia = Rui.Rui('A')
-		else:
-			self.ruia = ruia
+		self.ruia = ruia
+		if self.ruia is None:
+			print(self.ruip.uuid)
+			self.ruia = Rui(self.ruip.status, self.ruip.uuid)
 
-		# If we don't get info about whether Ruip is singularly unique
-		#	then we're going to assume it isn't
-		if unique is None:
-			self.unique = "-SU"
-		else:
-			self.unique = unique
-		
-		# If we don't get a timestamp for assignment of Ruip to some entity
-		#	(assigned by Ruia), then assume Ruia is assigning Ruip at runtime
-		if t is None:
-			self.t = datetime.now(timezone.utc)
-		else:
-			self.t = t
+		self.unique = unique
+		self.t = t
 
 # This class is the superclass of all Nto* tuples. They all relate some
 #	non-repeatable portion of reality to some portion of reality (in 
@@ -77,22 +55,18 @@ class NtoXGenericTuple(RtTuple):
 		super().__init__(ruit)
 		if ruin is None:
 			raise Exception("must provide a value for RUIn")
-		else:
-			self.ruin = ruin
 		if r is None:
 			raise Exception("must provide a value for r")
-		else:
-			self.r = r 
+		
+		self.ruin = ruin
+		self.r = r 
 
 # Except for NtoLackR, Nto* tuples can be asserted as being
 #  true or false (i.e., "it is not the case that...")
 class NtoXTuple(NtoXGenericTuple):
-	def __init__(self, ruit, ruin, r, polarity):
+	def __init__(self, ruit, ruin, r, polarity: bool):
 		super().__init__(ruit, ruin, r)
-		if (polarity):
-			self.polarity = True
-		else:
-			self.polarity = False
+		self.polarity = polarity
 
 	def isPositive(self):
 		return self.polarity

--- a/src/rtt/ntoxtuple.py
+++ b/src/rtt/ntoxtuple.py
@@ -1,5 +1,5 @@
 from src.ids_codes import Rui
-from rtt.atuple import NtoXTuple, NtoXGenericTuple
+from src.rtt.atuple import NtoXTuple, NtoXGenericTuple
 
 class NtoN(NtoXTuple):
 

--- a/src/rtt/ntoxtuple.py
+++ b/src/rtt/ntoxtuple.py
@@ -1,4 +1,4 @@
-from ids_codes import Rui
+from src.ids_codes import Rui
 from rtt.atuple import NtoXTuple, NtoXGenericTuple
 
 class NtoN(NtoXTuple):

--- a/src/rtt_meta/meta_tuple.py
+++ b/src/rtt_meta/meta_tuple.py
@@ -1,7 +1,5 @@
 from datetime import datetime, timezone
-import sys
-  
-from ids_codes import Rui
+from src.ids_codes import Rui
 
 class Dtuple:
 
@@ -33,7 +31,7 @@ class Ftuple:
 		self.C = C
 		# ruit denotes this Ftuple itself
 		if ruit is None:
-			self.ruit = Rui.Rui('A')
+			self.ruit = Rui.Rui(Rui.RuiStatus.assigned)
 		else:
 			self.ruit = ruit
 

--- a/tests/test_atuple.py
+++ b/tests/test_atuple.py
@@ -1,5 +1,5 @@
-from ids_codes import Rui
-from rtt.atuple import Atuple
+from src.ids_codes import Rui
+from src.rtt.atuple import Atuple
 from datetime import datetime, timezone
 
 def print_atuple(a):
@@ -13,17 +13,17 @@ def print_atuple(a):
 	print()
 
 
-a = Rui.Rui('A')
+a = Rui.Rui(Rui.RuiStatus.assigned)
 
-x = Rui.Rui('A')
+x = Rui.Rui(Rui.RuiStatus.assigned)
 y = Atuple(x)
 print_atuple(y)
 
-q = Rui.Rui('R')
+q = Rui.Rui(Rui.RuiStatus.reserved)
 z = Atuple(q, ruia=a, unique="+SU", ar='R')
 print_atuple(z)
 
-s = Rui.Rui('A')
+s = Rui.Rui(Rui.RuiStatus.assigned)
 w = Atuple(s, ruia=a, unique="+SU")
 print_atuple(w)
 

--- a/tests/test_code.py
+++ b/tests/test_code.py
@@ -1,5 +1,7 @@
-from ids_codes import Concept
-from ids_codes import Rui
+from src.ids_codes import Concept
+from src.ids_codes import Rui
+import sys
+sys.path.append('../src')
 
 
 def print_code(c):
@@ -18,7 +20,7 @@ def print_attribute(a):
 		print("\tattribute name is '",y,"'")
 	print()
 
-csrui = Rui.Rui('A')
+csrui = Rui.Rui(Rui.RuiStatus.assigned)
 c1 = Concept.Concept("12345678", csrui)
 c2 = Concept.Concept("98765432", csrui, "type 2 diabetes mellitus")
 

--- a/tests/test_meta_tuple.py
+++ b/tests/test_meta_tuple.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from ids_codes import Rui
+from src.ids_codes import Rui
 from rtt_meta.meta_tuple import Dtuple, Ftuple
 from rtt_meta.metadata_accessory import TupleEventType, RtChangeReason, RtErrorCode
 from rtt.atuple import Atuple
@@ -18,14 +18,14 @@ def print_f_tuple(ft):
 	print("\tta: ", ft.ta.isoformat().replace('+00:00', 'Z'))
 
 # create two Atuples with a = rui of person assigning rui to things
-a = Rui.Rui('A')
-s = Rui.Rui('A')
+a = Rui.Rui(Rui.RuiStatus.assigned)
+s = Rui.Rui(Rui.RuiStatus.assigned)
 w = Atuple(a, ruia=a, unique="+SU")
 x = Atuple(s, ruia=a, unique="+SU")
 
 # create two D tuples for each Atuple
 # the entity registering the tuples in the RTS
-dr = Rui.Rui('A')
+dr = Rui.Rui(Rui.RuiStatus.assigned)
 # metadata or D tuple for w (Atuple)
 dt1 = Dtuple(w.ruit, dr, TupleEventType.INSERT, RtChangeReason.RELEVANCE, None, datetime.now(timezone.utc), None)
 # metadata or D tuple for x (Atuple)

--- a/tests/test_meta_tuple.py
+++ b/tests/test_meta_tuple.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timezone
 from src.ids_codes import Rui
-from rtt_meta.meta_tuple import Dtuple, Ftuple
-from rtt_meta.metadata_accessory import TupleEventType, RtChangeReason, RtErrorCode
-from rtt.atuple import Atuple
+from src.rtt_meta.meta_tuple import Dtuple, Ftuple
+from src.rtt_meta.metadata_accessory import TupleEventType, RtChangeReason, RtErrorCode
+from src.rtt.atuple import Atuple
 
 
 # print functions 

--- a/tests/test_metadata_accessory.py
+++ b/tests/test_metadata_accessory.py
@@ -1,4 +1,4 @@
-from rtt_meta.metadata_accessory import TupleEventType, RtChangeReason, RtErrorCode, pretty_print_dict, description_dict
+from src.rtt_meta.metadata_accessory import TupleEventType, RtChangeReason, RtErrorCode, pretty_print_dict, description_dict
 
 print(TupleEventType.INSERT, "\t", pretty_print_dict[TupleEventType.INSERT])
 print()

--- a/tests/test_ntoxtuple.py
+++ b/tests/test_ntoxtuple.py
@@ -1,4 +1,4 @@
-from ids_codes import Rui
+from src.ids_codes import Rui
 from rtt.atuple import Atuple
 from rtt.ntoxtuple import NtoR, NtoN, NtoDE, NtoC, NtoLackR
 
@@ -35,32 +35,32 @@ def print_nton_tuple(nton):
 	print()
 
 # Rui that represents the person authoring these tuples
-a = Rui.Rui('A')
+a = Rui.Rui(Rui.RuiStatus.assigned)
 # Rui that stands for the repeatable PoR called "human being"
-h = Rui.Rui('A')
+h = Rui.Rui(Rui.RuiStatus.assigned)
 # Rui that stands for interval over which author has been instance of human being
-tr1 = Rui.Rui('A')
+tr1 = Rui.Rui(Rui.RuiStatus.assigned)
 k = Atuple(tr1, ruia=a)
 
 ntor = NtoR(None, a, True, "instance of", h, tr1)
 print_ntor_tuple(ntor)
 
 #let x be the RUI standing for Kuala Lumpur
-x = Rui.Rui('A')
+x = Rui.Rui(Rui.RuiStatus.assigned)
 y = Atuple(x)
 print_atuple(y)
 
-q = Rui.Rui('R')
+q = Rui.Rui(Rui.RuiStatus.reserved)
 z = Atuple(q, ruia=a, unique="+SU", ar='R')
 print_atuple(z)
 
 #let s be the RUI standing for the territory of Malaysia
-s = Rui.Rui('A')
+s = Rui.Rui(Rui.RuiStatus.assigned)
 w = Atuple(s, ruia=a, unique="+SU")
 print_atuple(w)
 
 #let tr2 be interval over which kuala lumpur has been part of Malaysia
-tr2 = Rui.Rui('A')
+tr2 = Rui.Rui(Rui.RuiStatus.assigned)
 j = Atuple(tr2, ruia=a)
 nton = NtoN(None, x, True, "part of", [x, s], tr2)
 print_nton_tuple(nton)

--- a/tests/test_ntoxtuple.py
+++ b/tests/test_ntoxtuple.py
@@ -1,6 +1,6 @@
 from src.ids_codes import Rui
-from rtt.atuple import Atuple
-from rtt.ntoxtuple import NtoR, NtoN, NtoDE, NtoC, NtoLackR
+from src.rtt.atuple import Atuple
+from src.rtt.ntoxtuple import NtoR, NtoN, NtoDE, NtoC, NtoLackR
 
 def print_atuple(a):
 	print("A tuple information:")

--- a/tests/test_rui.py
+++ b/tests/test_rui.py
@@ -1,4 +1,4 @@
-from ids_codes.Rui import Rui, TempRef
+from src.ids_codes.Rui import Rui, TempRef, RuiStatus
 from uuid6 import uuid7
 from datetime import datetime, timezone
 
@@ -16,9 +16,9 @@ def print_tr(tr):
 	else:
 		print("cal field=", tr.cal)
 
-x = Rui('A')
-y = Rui('R')
-z = Rui('R')
+x = Rui(RuiStatus.assigned)
+y = Rui(RuiStatus.reserved)
+z = Rui(RuiStatus.reserved)
 
 print_info(x)
 print_info(y)


### PR DESCRIPTION
Made Rui more pythonic without changing the functionality of the class by leveraging Enums. The a_or_r field was converted to an Enum instead of a String in order to reflect the invariant nature of the statuses and the potential expansion of more statuses. I then made the corresponding changes in the other modules to reflect the shift to the enum. 

Imports were then changed to allow for pytest to be run from the project's root directory. 