### PR TITLE
Initial Test Development

### DIFF
--- a/src/rtt/atuple.py
+++ b/src/rtt/atuple.py
@@ -1,24 +1,27 @@
-from uuid6 import uuid7
 from datetime import datetime, timezone
   
 from src.ids_codes.Rui import Rui, RuiStatus
 
 class RtTuple:
-	def __init__(self, ruit):
-		if ruit is None:
-			self.ruit = Rui(RuiStatus.assigned)
-		else:	
-			self.ruit = ruit
+	def __init__(self, ruit=None):
+		self.ruit = ruit if ruit else Rui(RuiStatus.assigned)
 
 	def get_ruit(self):
 		return self.ruit 
 
-# Assignment tuple, i.e., assigment of a Rui to some entity in reality
-#  We can also reserve a Rui, and this class has the ar parameter to 
-#	capture that. Depending on whether 
+
 class Atuple(RtTuple):
-	"""Referent Tracking assignment tuple that registers assignment of an RUI to a PoR"""
-	def __init__(self, ruip=Rui(RuiStatus.assigned), ruia=None, ruit=None, unique="-SU", ar=RuiStatus.assigned, t=datetime.now(timezone.utc)):
+	"""Referent Tracking assignment tuple that registers assignment of an RUI to a PoR
+	
+	Attributes:
+	ar -- The status of ruip
+	ruip -- The Rui that is being assigned for the first time
+	ruia -- The Rui of the author of this Atuple
+	unique -- 
+	t -- The time of the creation of the Atuple
+	"""
+
+	def __init__(self, ruip=None, ruia=None, ruit=None, unique="-SU", ar=RuiStatus.assigned, t=datetime.now(timezone.utc)):
 		super().__init__(ruit)
 
 		# If we don't get a value for whether the Rui is assigned or reserved
@@ -26,7 +29,7 @@ class Atuple(RtTuple):
 		self.ar = ar
 
 		# If we don't get a Ruip, then we'll create one on the fly
-		self.ruip = ruip 
+		self.ruip = ruip if ruip else Rui(self.ar)
 		
 		# If we don't get an author Rui for the tuple, then autogenerate one,
 		#	unless we don't get a Ruip either, in which case set it to the
@@ -41,6 +44,11 @@ class Atuple(RtTuple):
 
 		self.unique = unique
 		self.t = t
+
+	def getTimestamp(self):
+		return self.t
+	
+
 
 # This class is the superclass of all Nto* tuples. They all relate some
 #	non-repeatable portion of reality to some portion of reality (in 

--- a/src/rtt/atuple.py
+++ b/src/rtt/atuple.py
@@ -47,39 +47,3 @@ class Atuple(RtTuple):
 
 	def getTimestamp(self):
 		return self.t
-	
-
-
-# This class is the superclass of all Nto* tuples. They all relate some
-#	non-repeatable portion of reality to some portion of reality (in 
-#	some cases a repeatable PoR, and in others non-repeatable ones) or
-#	in the case of NtoC, it is asserting that the N is "annotated by"
-#	the "concept" from some concept system.
-# We require the NtoXGenericTuple to accomodate NtoLackR
-#	All the other Nto* tuples extend NtoXTuple
-# 
-class NtoXGenericTuple(RtTuple):
-	def __init__(self, ruit, ruin, r):
-		super().__init__(ruit)
-		if ruin is None:
-			raise Exception("must provide a value for RUIn")
-		if r is None:
-			raise Exception("must provide a value for r")
-		
-		self.ruin = ruin
-		self.r = r 
-
-# Except for NtoLackR, Nto* tuples can be asserted as being
-#  true or false (i.e., "it is not the case that...")
-class NtoXTuple(NtoXGenericTuple):
-	def __init__(self, ruit, ruin, r, polarity: bool):
-		super().__init__(ruit, ruin, r)
-		self.polarity = polarity
-
-	def isPositive(self):
-		return self.polarity
-
-	def isNegated(self):
-		return not self.polarity
-
-

--- a/src/rtt/ntoxtuple.py
+++ b/src/rtt/ntoxtuple.py
@@ -1,5 +1,38 @@
 from src.ids_codes import Rui
-from src.rtt.atuple import NtoXTuple, NtoXGenericTuple
+from src.rtt.atuple import RtTuple
+
+# This class is the superclass of all Nto* tuples. They all relate some
+#	non-repeatable portion of reality to some portion of reality (in 
+#	some cases a repeatable PoR, and in others non-repeatable ones) or
+#	in the case of NtoC, it is asserting that the N is "annotated by"
+#	the "concept" from some concept system.
+# We require the NtoXGenericTuple to accomodate NtoLackR
+#	All the other Nto* tuples extend NtoXTuple
+# 
+class NtoXGenericTuple(RtTuple):
+	def __init__(self, ruit, ruin, r):
+		super().__init__(ruit)
+		if ruin is None:
+			raise Exception("must provide a value for RUIn")
+		if r is None:
+			raise Exception("must provide a value for r")
+		
+		self.ruin = ruin
+		self.r = r 
+
+# Except for NtoLackR, Nto* tuples can be asserted as being
+#  true or false (i.e., "it is not the case that...")
+class NtoXTuple(NtoXGenericTuple):
+	def __init__(self, ruit, ruin, r, polarity: bool):
+		super().__init__(ruit, ruin, r)
+		self.polarity = polarity
+
+	def isPositive(self):
+		return self.polarity
+
+	def isNegated(self):
+		return not self.polarity
+
 
 class NtoN(NtoXTuple):
 

--- a/src/rtt_meta/meta_tuple.py
+++ b/src/rtt_meta/meta_tuple.py
@@ -1,11 +1,12 @@
 from datetime import datetime, timezone
 from src.ids_codes import Rui
+from src.rtt import atuple
 
-class Dtuple:
+class Dtuple(atuple.RtTuple):
 
 	# D#< RUId, RUIT, t, ‘I’/E, R, S >
 	def __init__(self, ruit, ruid, event, event_reason, error, td=None, replacements=None):
-		self.ruit = ruit
+		super().__init__(ruit)
 		self.ruid = ruid
 		self.event = event
 		self.event_reason = event_reason
@@ -19,19 +20,14 @@ class Dtuple:
 		else:
 			self.replacements = replacements.copy()
 
-class Ftuple:
-	
+class Ftuple(atuple.RtTuple):
 	#F#< RUId, ta, RUIa, RUIT, C >
 	def __init__(self, ruitn, ruia, ta, C, ruit=None):
+		super().__init__(ruit)
 		# ruitn denotes the tuple that this Ftuple is about
 		self.ruitn = ruitn
 		self.ruia = ruia
 		#TO DO - we need to figure out how to do time parameters
 		self.ta = ta
 		self.C = C
-		# ruit denotes this Ftuple itself
-		if ruit is None:
-			self.ruit = Rui.Rui(Rui.RuiStatus.assigned)
-		else:
-			self.ruit = ruit
 

--- a/tests/test_atuple.py
+++ b/tests/test_atuple.py
@@ -4,7 +4,7 @@ from datetime import datetime, timezone
 
 def print_atuple(a):
 	print("tuple information:")
-	print("\truit: the rui that denotes tuple itself", str(a.ruit.uuid))
+	print("\truit: the rui that denotes tuple itself", str(a.get_ruit().uuid))
 	print("\truip: rui that was assigned to some PoR", str(a.ruip.uuid))
 	print("\tis ruip reserved? ", a.ruip.is_reserved())
 	print('\tis ruip singularly unique vs. potentially non-singularly unique: ', a.unique)

--- a/tests/test_meta_tuple.py
+++ b/tests/test_meta_tuple.py
@@ -7,14 +7,14 @@ from src.rtt.atuple import Atuple
 
 # print functions 
 def print_d_tuple(dt):
-	print("<", dt.ruid.uuid, "> did a(n) ", dt.event, " to tuple <", dt.ruit.uuid, "> because of ", dt.event_reason, " at ", str(dt.td))
+	print("<", dt.ruid.uuid, "> did a(n) ", dt.event, " to tuple <", dt.get_ruit().uuid, "> because of ", dt.event_reason, " at ", str(dt.td))
 	print("\tany associated error code: ", dt.error)
 	print("\tany replacement tuples: ", dt.replacements) 
 	print()
 
 def print_f_tuple(ft):
 	print("<", ft.ruia.uuid, "> has confidence level '", ft.C, "' in tuple <", ft.ruitn.uuid, "> at ", ft.ta)
-	print("\ttuple rui: ", ft.ruit.uuid)
+	print("\ttuple rui: ", ft.get_ruit().uuid)
 	print("\tta: ", ft.ta.isoformat().replace('+00:00', 'Z'))
 
 # create two Atuples with a = rui of person assigning rui to things

--- a/tests/test_ntoxtuple.py
+++ b/tests/test_ntoxtuple.py
@@ -4,7 +4,7 @@ from src.rtt.ntoxtuple import NtoR, NtoN, NtoDE, NtoC, NtoLackR
 
 def print_atuple(a):
 	print("A tuple information:")
-	print("\truit: the rui that denotes tuple itself", str(a.ruit.uuid))
+	print("\truit: the rui that denotes tuple itself", str(a.get_ruit().uuid))
 	print("\truip: rui that was assigned to some PoR", str(a.ruip.uuid))
 	print("\tis ruip reserved? ", a.ruip.is_reserved())
 	print('\tis ruip singularly unique vs. potentially non-singularly unique: ', a.unique)
@@ -14,7 +14,7 @@ def print_atuple(a):
 
 def print_ntor_tuple(ntor):
 	print("NtoR tuple information:")
-	print("\truit: the rui that the system assigned to the NtoR tuple itself --", str(ntor.ruit.uuid))
+	print("\truit: the rui that the system assigned to the NtoR tuple itself --", str(ntor.get_ruit().uuid))
 	print("\truin: the rui that denotes the non-repeatable PoR that this tuple is about --", str(ntor.ruin.uuid))
 	print("\truir: the rui that denotes the repeatable PoR to which the non-repeatable PoR (denoted by ruinI) is related --", ntor.ruir.uuid)
 	print("\tr: the relationship between the non-repeatable PoR and the repeatable PoR --", str(ntor.r))
@@ -24,7 +24,7 @@ def print_ntor_tuple(ntor):
 
 def print_nton_tuple(nton):
 	print("NtoN tuple information:")
-	print("\truit: the rui that the system assigned to the NtoR tuple itself --", str(nton.ruit.uuid))
+	print("\truit: the rui that the system assigned to the NtoR tuple itself --", str(nton.get_ruit().uuid))
 	print("\truin: the rui that denotes the non-repeatable PoR that this tuple is about --", str(nton.ruin.uuid))
 	print("\tP: the list of ruis that denote the non-repeatable PoRs that are related by r:")
 	for i in nton.p_list:

--- a/tests/test_rui.py
+++ b/tests/test_rui.py
@@ -16,18 +16,28 @@ def print_tr(tr):
 	else:
 		print("cal field=", tr.cal)
 
-x = Rui(RuiStatus.assigned)
-y = Rui(RuiStatus.reserved)
-z = Rui(RuiStatus.reserved)
 
-print_info(x)
-print_info(y)
-print()
-print("z before status change")
-print_info(z)
-z.update_status_assigned()
-print("\nz after status change")
-print_info(z)
+def test_RuiStatus():
+	a = Rui(RuiStatus.assigned)
+	assert(a.is_assigned())
+	assert(a.status is RuiStatus.assigned)
+	assert(not a.is_reserved())
+
+	a.update_status_assigned()
+	assert(a.is_assigned())
+	assert(a.status is RuiStatus.assigned)
+	assert(not a.is_reserved())
+
+	r = Rui(RuiStatus.reserved)
+	assert(r.is_reserved())
+	assert(r.status is RuiStatus.reserved)
+	assert(not r.is_assigned())
+
+	r.update_status_assigned()
+	assert(r.is_assigned())
+	assert(r.status is RuiStatus.assigned)
+	assert(not r.is_reserved())
+
 
 j = TempRef(uuid7())
 k = TempRef(datetime.now(timezone.utc))


### PR DESCRIPTION
The first pytest compatible function was created in test_rui.py. In addition, all tuples were made into children of RtTuples, as they all are RT tuples. Additional changes to how fields were accessed were required in order for the previous change to function properly. 