### PR TITLE
Initial framework for tuple query requests and abstract storage class

### DIFF
--- a/src/rt_core_v2/ids_codes/Rui.py
+++ b/src/rt_core_v2/ids_codes/Rui.py
@@ -22,9 +22,6 @@ class Rui:
 	def __str__(self):
 		return str(self._uuid)
 	
-	def toJSON(self):
-		return str(self._uuid)
-	
 	def __eq__(self, other):
 		if not isinstance(other, type(self)):
 			return False
@@ -44,9 +41,6 @@ class TempRef:
 		self.ref = tr if tr else Rui()
 	
 	def __str__(self):
-		return str(self.ref)
-	
-	def toJSON(self):
 		return str(self.ref)
 	
 	def __eq__(self, other):

--- a/src/rt_core_v2/persist/rts_store.py
+++ b/src/rt_core_v2/persist/rts_store.py
@@ -1,0 +1,125 @@
+from abc import ABC, abstractmethod
+from typing import Optional
+
+from rt_core_v2.rttuple import RtTuple, TupleType, TupleComponents
+from rt_core_v2.ids_codes.Rui import Rui, TempRef
+from rt_core_v2.metadata_accessory import RtChangeReason, TupleEventType
+
+#TODO Change fields to be up to date with referent tracking 2.0 
+class TupleQuery():
+    def __init__(self):
+        self.types: set[TupleType] = set()
+        self.rui: Optional[Rui] = None
+        self.relationship_rui: Optional[Rui] = None
+        self.universal_rui: Optional[Rui] = None
+        self.author_rui: Optional[Rui] = None
+        self.authoring_time_rui: Optional[Rui] = None
+        self.begin_timestamp: Optional[TempRef] = None
+        self.end_timestamp: Optional[TempRef] = None
+        self.data: Optional[bytes] = None
+        self.datatype: Optional[Rui] = None
+        self.change_reason: Optional[RtChangeReason] = None
+        self.error_code: Optional[TupleEventType] = None
+        self.temporal_entity_name: Optional[str] = None
+        self.tr: Optional[TempRef] = None
+        #TODO Figure out particular reference type for self.p
+        self.p: Optional[Rui] = None
+        self.polarity: Optional[bool] = None
+
+    #TODO Make this general
+    # def parameters_match_tuple(self, tuple_type):
+    
+    def match_atuple(self):
+        if self.types and TupleType.A not in self.types:
+            return False
+        if self.relationship_rui or self.data or self.change_reason or self.datatype or self.error_code or self.temporal_entity_name or self.universal_rui or self.polarity:
+            return False
+        return True
+    
+    def match_dtuple(self):
+        if self.types and TupleType.D not in self.types:
+            return False
+        if self.data or self.datatype or self.temporal_entity_name or self.relationship_rui or self.universal_rui or self.polarity:
+            return False
+        return True
+    
+    #TODO Fill out ftuple match
+    def match_ftuple(self):
+        if self.types and TupleType.F not in self.types:
+            return False
+        return True
+    
+    def match_ntontuple(self):
+        if self.types and TupleType.NtoNTuple not in self.types:
+            return False
+        if self.datatype or self.change_reason or self.error_code or self.temporal_entity_name or self.universal_rui:
+            return False
+        return True
+    
+    def match_ntortuple(self):
+        if self.types and TupleType.NtoRTuple not in self.types:
+            return False
+        if self.data or self.datatype or self.change_reason or self.error_code or self.temporal_entity_name:
+            return False
+        return True
+    
+    #TODO Fill out ntoc tuple
+    def match_ntoctuple(self):
+        if self.types and TupleType.NtoC not in self.types:
+            return False
+        return True
+    
+    #TODO Fill out ntode tuple
+    def match_ntodetuple(self):
+        if self.types and TupleType.NtoDE not in self.types:
+            return False
+        return True
+    
+    def ntolackrtuple(self):
+        if self.types and TupleType.NtoLackR not in self.types:
+            return False
+        if self.data or self.datatype or self.change_reason or self.error_code or self.temporal_entity_name or self.polarity:
+            return False
+        return True
+
+class RtStore(ABC):
+
+    @abstractmethod
+    def save_tuple(self, tup: RtTuple) -> bool:
+        pass
+
+    @abstractmethod
+    def get_tuple(self, tup: RtTuple) -> Rui:
+        pass
+
+    @abstractmethod
+    def get_by_referent(self, rui: Rui) -> set[RtTuple]:
+        pass
+
+    @abstractmethod
+    def get_by_author(self, rui: Rui) -> Rui:
+        pass
+
+    @abstractmethod
+    def get_available_rui(self) -> Rui:
+        pass
+
+    @abstractmethod
+    def get_by_type(self, referentType, designatorType, designatorText) -> set:
+        pass
+
+    @abstractmethod
+    def run_query(self, query) -> set[RtTuple]:
+        pass
+
+    @abstractmethod
+    def shut_down(self):
+        pass
+
+    @abstractmethod
+    def commit(self):
+        pass
+
+    @abstractmethod
+    def save_rts_declaration(self, declaration) -> bool:
+        pass

--- a/src/rt_core_v2/rttuple.py
+++ b/src/rt_core_v2/rttuple.py
@@ -56,7 +56,6 @@ class TupleComponents(enum.Enum):
 	ruir = 'ruir'
 	ruics = 'ruics'
 	code = 'code'
-	ruins = 'ruins'
 	data = 'data'
 	ruidt = 'ruidt'
 
@@ -370,22 +369,20 @@ class NtoDETuple(RtTuple):
 	
 	Attributes:
 	polarity -- Boolean describing whether the relation is as stated or negated
-	ruin -- 
-	ruins -- 
+	ruin -- The Rui of the tuple that the data is atrributed to
 	data -- The data in the relationship
 	ruidt -- An Rui containing the data type of data
 	"""
-	#NtoDE#< '+/-', r, ruin, ruins, data, ruidt>
+	#NtoDE#< '+/-', r, ruin, data, ruidt>
 
 	tuple_type = TupleType.NtoDE
 	params = {**RtTuple.params, **enum_to_dict({TupleComponents.polarity, TupleComponents.ruin, 
-											   TupleComponents.ruins, TupleComponents.data, TupleComponents.ruidt})}
+											   TupleComponents.data, TupleComponents.ruidt})}
 
-	def __init__(self, ruit: Rui, polarity: bool, ruin: Rui, ruins: Rui, data, ruidt: Rui):
+	def __init__(self, ruit: Rui, polarity: bool, ruin: Rui, data, ruidt: Rui):
 		super().__init__(ruit)
 		self.polarity = polarity
 		self.ruin = ruin
-		self.ruins = ruins
 		self.data = data
 		self.ruidt = ruidt
 
@@ -394,7 +391,6 @@ class NtoDETuple(RtTuple):
 		attributes = super().get_str_attributes()
 		attributes[self.params[TupleComponents.polarity]] = self.polarity
 		attributes[self.params[TupleComponents.ruin]] = str(self.ruin)
-		attributes[self.params[TupleComponents.ruins]] = str(self.ruins)
 		attributes[self.params[TupleComponents.data]] = str(self.data)
 		attributes[self.params[TupleComponents.ruidt]] = str(self.ruidt)
 		return attributes

--- a/src/rt_core_v2/rttuple.py
+++ b/src/rt_core_v2/rttuple.py
@@ -86,9 +86,9 @@ class RtTuple(ABC):
 		return self.__dict__ == other.__dict__
 
 	@abstractmethod
-	def get_str_attributes(self) -> dict:
-		"""Get the attributes of this tuple as a string"""
-		return {self.params[TupleComponents.ruit]:str(self._rui), self.params[TupleComponents.type]:str(self.tuple_type)}
+	def get_attributes(self) -> dict:
+		"""Get the attributes of this tuplestring"""
+		return {self.params[TupleComponents.ruit]:str(self._rui), self.params[TupleComponents.type]:self.tuple_type.value}
 
 class ATuple(RtTuple):
 	"""Referent Tracking assignment tuple that registers assignment of an RUI to a PoR
@@ -136,9 +136,9 @@ class ATuple(RtTuple):
 		"""Returns whether this tuple is a reservation or not"""
 		return self.ar is RuiStatus.reserved
 
-	def get_str_attributes(self):
-		"""Get the attributes of this tuple as a string"""
-		attributes = super().get_str_attributes()
+	def get_attributes(self):
+		"""Get the attributes of this tuplestring"""
+		attributes = super().get_attributes()
 		attributes[self.params[TupleComponents.ruia]] = str(self.ruia)
 		attributes[self.params[TupleComponents.ruip]] = str(self.ruip)
 		attributes[self.params[TupleComponents.ar]] = str(self.ar)
@@ -181,15 +181,15 @@ class DTuple(RtTuple):
 		self.td = t if t else TempRef()
 		self.replacements = replacements.copy()
 
-	def get_str_attributes(self):
-		"""Get the attributes of this tuple as a string"""
+	def get_attributes(self):
+		"""Get the attributes of this tuplestring"""
 		attributes = {}
-		attributes[self.params[TupleComponents.type]] = self.tuple_type
-		attributes[self.params[TupleComponents.ruid]] = self.ruid
-		attributes[self.params[TupleComponents.ruit]] = self.ruit_ref
+		attributes[self.params[TupleComponents.type]] = self.tuple_type.value
+		attributes[self.params[TupleComponents.ruid]] = str(self.ruid)
+		attributes[self.params[TupleComponents.ruit]] = str(self.ruit_ref)
 		attributes[self.params[TupleComponents.event]] = self.event.value
 		attributes[self.params[TupleComponents.event_reason]] = self.event_reason.value
-		attributes[self.params[TupleComponents.t]] = self.td
+		attributes[self.params[TupleComponents.t]] = str(self.td)
 		attributes[self.params[TupleComponents.replacements]] = self.replacements
 		return attributes
 	
@@ -223,8 +223,8 @@ class FTuple(RtTuple):
 		self.ta = ta
 		self.C = C
 
-	def get_str_attributes(self):
-		"""Get the attributes of this tuple as a string"""
+	def get_attributes(self):
+		"""Get the attributes of this tuple"""
 		attributes = {}
 		attributes[self.params[TupleComponents.type]] = str(self.tuple_type)
 		attributes[self.params[TupleComponents.ruid]] = str(self.ruid)
@@ -268,9 +268,9 @@ class NtoNTuple(RtTuple):
 		self.time_relation = rT
 		self.time = tr
 	
-	def get_str_attributes(self):
-		"""Get the attributes of this tuple as a string"""
-		attributes = super().get_str_attributes()
+	def get_attributes(self):
+		"""Get the attributes of this tuplestring"""
+		attributes = super().get_attributes()
 		attributes[self.params[TupleComponents.polarity]] = self.polarity
 		attributes[self.params[TupleComponents.r]] = str(self.relation)
 		attributes[self.params[TupleComponents.p_list]] = self.p_list
@@ -304,9 +304,9 @@ class NtoRTuple(RtTuple):
 		self.time_relation = rT
 		self.time = tr 
 
-	def get_str_attributes(self):
-		"""Get the attributes of this tuple as a string"""
-		attributes = super().get_str_attributes()
+	def get_attributes(self):
+		"""Get the attributes of this tuplestring"""
+		attributes = super().get_attributes()
 		attributes[self.params[TupleComponents.polarity]] = self.polarity
 		attributes[self.params[TupleComponents.inst]] = str(self.inst)
 		attributes[self.params[TupleComponents.ruin]] = str(self.ruin)
@@ -345,9 +345,9 @@ class NtoCTuple(RtTuple):
 		self.time_relation = rT
 		self.time = tr
 
-	def get_str_attributes(self):
-		"""Get the attributes of this tuple as a string"""
-		attributes = super().get_str_attributes()
+	def get_attributes(self):
+		"""Get the attributes of this tuplestring"""
+		attributes = super().get_attributes()
 		attributes[self.params[TupleComponents.polarity]] = self.polarity
 		attributes[self.params[TupleComponents.r]] = str(self.reason)
 		attributes[self.params[TupleComponents.ruics]] = str(self.ruics)
@@ -386,9 +386,9 @@ class NtoDETuple(RtTuple):
 		self.data = data
 		self.ruidt = ruidt
 
-	def get_str_attributes(self):
-		"""Get the attributes of this tuple as a string"""
-		attributes = super().get_str_attributes()
+	def get_attributes(self):
+		"""Get the attributes of this tuplestring"""
+		attributes = super().get_attributes()
 		attributes[self.params[TupleComponents.polarity]] = self.polarity
 		attributes[self.params[TupleComponents.ruin]] = str(self.ruin)
 		attributes[self.params[TupleComponents.data]] = str(self.data)
@@ -396,7 +396,7 @@ class NtoDETuple(RtTuple):
 		return attributes
 
 class NtoLackRTuple(RtTuple):
-	"""Tuple type that relates a non-repeatable portion of reality to a repeatable portion of reality in a negative relationship
+	"""Tuple type that asserts that a repeatable portion of reality in a does not have a specified relationship with a non-repeateble portion of reality
 	
 	Attribtues:
 	relation -- A relationship between a non-repeatable portion of reality and a repeatable portion of reality
@@ -420,9 +420,9 @@ class NtoLackRTuple(RtTuple):
 		self.time_relation = rT
 		self.time = tr 
 
-	def get_str_attributes(self):
-		"""Get the attributes of this tuple as a string"""
-		attributes = super().get_str_attributes()
+	def get_attributes(self):
+		"""Get the attributes of this tuplestring"""
+		attributes = super().get_attributes()
 		attributes[self.params[TupleComponents.r]] = str(self.relation)
 		attributes[self.params[TupleComponents.ruip]] = str(self.ruip)
 		attributes[self.params[TupleComponents.ruir]] = str(self.ruir)

--- a/src/rt_core_v2/rttuple.py
+++ b/src/rt_core_v2/rttuple.py
@@ -118,15 +118,7 @@ class ATuple(RtTuple):
 		#	itself, and thus should be equal
 		self.ruia = ruia if ruia else Rui(self.ruip.uuid)
 		self.unique = unique 
-		self._t = t if t else TempRef()
-	@property
-	def t(self):
-		"""Get t"""
-		return self._t
-	@t.setter
-	def t(self, t):
-		"""Set t"""
-		self._t = t
+		self.t = t if t else TempRef()
 
 	def is_assigned(self):
 		"""Returns whether this tuple is an assignment or not"""
@@ -143,18 +135,8 @@ class ATuple(RtTuple):
 		attributes[self.params[TupleComponents.ruip]] = self.ruip
 		attributes[self.params[TupleComponents.ar]] = self.ar
 		attributes[self.params[TupleComponents.unique]] = self.unique
-		attributes[self.params[TupleComponents.t]] = self._t
+		attributes[self.params[TupleComponents.t]] = self.t
 		return attributes
-
-	def create_assigned(self):
-		"""Create an assignment A-tuple if this tuple is reserved"""
-		if self.status is RuiStatus.assigned:
-			logging.warning("status of Rui instance is already assigned. No change.")
-			return self
-		else:
-			#TODO Figure out the process for creating d-tuples
-			# return ATuple(self.ruip, self.ruia, self.ruit, self.unique, RuiStatus())
-			pass
 
 class DTuple(RtTuple):
 	""" Referent Tracking metadata tuple that stores information regarding the instantation of other tuple types
@@ -173,13 +155,13 @@ class DTuple(RtTuple):
 											 TupleComponents.event_reason, TupleComponents.t, 
 											 TupleComponents.replacements})}
 
-	def __init__(self, ruid: Rui, ruit: Rui, t: TempRef, event: TupleEventType, event_reason: RtChangeReason, replacements: list[Rui]=[]):
+	def __init__(self, ruit: Rui, t: TempRef, event: TupleEventType, event_reason: RtChangeReason, ruid: Rui=None, replacements: list[Rui]=None):
 		super().__init__(ruid)
 		self.ruit_ref = ruit
 		self.event = event
 		self.event_reason = event_reason
 		self.td = t if t else TempRef()
-		self.replacements = replacements.copy()
+		self.replacements = replacements.copy() if replacements else []
 
 	def get_attributes(self):
 		"""Get the attributes of this tuplestring"""
@@ -218,9 +200,9 @@ class FTuple(RtTuple):
 	
 	def __init__(self, ruid: Rui=None, ruit: Rui=None, ta: TempRef=None, ruia: Rui=None, C: float=1.0):
 		super().__init__(ruid)
-		self.ruit_ref = ruit
-		self.ruia = ruia
-		self.ta = ta
+		self.ruit_ref = ruit if ruit else Rui()
+		self.ruia = ruia if ruia else Rui()
+		self.ta = ta 
 		self.C = C
 	def get_attributes(self):
 		"""Get the attributes of this tuple"""
@@ -259,13 +241,13 @@ class NtoNTuple(RtTuple):
 	params = {**RtTuple.params, **enum_to_dict({TupleComponents.polarity, TupleComponents.r, 
 											 TupleComponents.p_list, TupleComponents.rT, TupleComponents.tr})}
 
-	def __init__(self, ruit: Rui, polarity: bool, r: str, p: list[Rui], rT, tr: TempRef):
+	def __init__(self, polarity: bool=True, r: str="", p: list[Rui]=None, rT="", tr: TempRef=None, ruit: Rui=None):
 		super().__init__(ruit)
 		self.polarity = polarity
 		self.relation = r
-		self.p_list = p.copy()
+		self.p_list = p.copy() if p else []
 		self.time_relation = rT
-		self.time = tr
+		self.time = tr 
 	
 	def get_attributes(self):
 		"""Get the attributes of this tuplestring"""
@@ -294,12 +276,12 @@ class NtoRTuple(RtTuple):
 	params = {**RtTuple.params, **enum_to_dict({TupleComponents.polarity, TupleComponents.inst, TupleComponents.ruin, 
 											   TupleComponents.ruir, TupleComponents.rT, TupleComponents.tr})}
 
-	def __init__(self, ruit: Rui, polarity: bool, inst: str, ruin: Rui, ruir: Rui, rT, tr: TempRef):
+	def __init__(self, ruit: Rui=None, polarity: bool=True, inst: str="", ruin: Rui=None, ruir: Rui=None, rT="", tr: TempRef=None):
 		super().__init__(ruit)
 		self.polarity = polarity
 		self.inst = inst
-		self.ruin = ruin
-		self.ruir = ruir
+		self.ruin = ruin if ruin else Rui()
+		self.ruir = ruir if ruir else Rui()
 		self.time_relation = rT
 		self.time = tr 
 
@@ -334,15 +316,16 @@ class NtoCTuple(RtTuple):
 	params = {**RtTuple.params, **enum_to_dict({TupleComponents.polarity, TupleComponents.r, TupleComponents.ruics, 
 											   TupleComponents.ruip, TupleComponents.code, TupleComponents.rT, TupleComponents.tr})}
 	#TODO Change code to be bytecode
-	def __init__(self, ruit: Rui, polarity: bool, r: str, ruics: Rui, ruip: Rui, code: str, rT, tr: TempRef):
+	#TODO Make creating a tempref create an underlying time instance
+	def __init__(self, ruit: Rui=None, polarity: bool=True, r: str="", ruics: Rui=None, ruip: Rui=None, code: str="", rT="", tr: TempRef=None):
 		super().__init__(ruit)
 		self.polarity = polarity
 		self.reason = r
-		self.ruics = ruics
-		self.ruip = ruip
-		self.code = code
+		self.ruics = ruics if ruics else Rui()
+		self.ruip = ruip if ruip else Rui()
+		self.code = code 
 		self.time_relation = rT
-		self.time = tr
+		self.time = tr 
 
 	def get_attributes(self):
 		"""Get the attributes of this tuplestring"""
@@ -378,12 +361,12 @@ class NtoDETuple(RtTuple):
 	params = {**RtTuple.params, **enum_to_dict({TupleComponents.polarity, TupleComponents.ruin, 
 											   TupleComponents.data, TupleComponents.ruidt})}
 
-	def __init__(self, ruit: Rui, polarity: bool, ruin: Rui, data, ruidt: Rui):
+	def __init__(self, ruit: Rui=None, polarity: bool=True, ruin: Rui=None, data="", ruidt: Rui=None):
 		super().__init__(ruit)
 		self.polarity = polarity
-		self.ruin = ruin
+		self.ruin = ruin if ruin else Rui()
 		self.data = data
-		self.ruidt = ruidt
+		self.ruidt = ruidt if ruidt else Rui()
 
 	def get_attributes(self):
 		"""Get the attributes of this tuplestring"""
@@ -411,12 +394,12 @@ class NtoLackRTuple(RtTuple):
 													  TupleComponents.ruir, TupleComponents.rT, TupleComponents.tr})}
 	
 
-	def __init__(self, ruit: Rui, r: str, ruip: Rui, ruir: Rui, rT, tr: TempRef):
+	def __init__(self, ruit: Rui=None, r: str="", ruip: Rui=None, ruir: Rui=None, rT="", tr: TempRef=None):
 		super().__init__(ruit)
 		self.relation = r
-		self.ruip = ruip
-		self.ruir = ruir
-		self.time_relation = rT
+		self.ruip = ruip if ruip else Rui()
+		self.ruir = ruir if ruir else Rui()
+		self.time_relation = rT 
 		self.time = tr 
 
 	def get_attributes(self):

--- a/src/rt_core_v2/rttuple.py
+++ b/src/rt_core_v2/rttuple.py
@@ -88,7 +88,7 @@ class RtTuple(ABC):
 	@abstractmethod
 	def get_attributes(self) -> dict:
 		"""Get the attributes of this tuplestring"""
-		return {self.params[TupleComponents.ruit]:str(self._rui), self.params[TupleComponents.type]:self.tuple_type.value}
+		return {self.params[TupleComponents.ruit]:self._rui, self.params[TupleComponents.type]:self.tuple_type}
 
 class ATuple(RtTuple):
 	"""Referent Tracking assignment tuple that registers assignment of an RUI to a PoR
@@ -117,7 +117,7 @@ class ATuple(RtTuple):
 		#	are provided, we are assuming some entity is assigning a Ruip to 
 		#	itself, and thus should be equal
 		self.ruia = ruia if ruia else Rui(self.ruip.uuid)
-		self.unique = unique if type(unique) is PorType else PorType(unique)
+		self.unique = unique 
 		self._t = t if t else TempRef()
 	@property
 	def t(self):
@@ -139,11 +139,11 @@ class ATuple(RtTuple):
 	def get_attributes(self):
 		"""Get the attributes of this tuplestring"""
 		attributes = super().get_attributes()
-		attributes[self.params[TupleComponents.ruia]] = str(self.ruia)
-		attributes[self.params[TupleComponents.ruip]] = str(self.ruip)
-		attributes[self.params[TupleComponents.ar]] = str(self.ar)
-		attributes[self.params[TupleComponents.unique]] = str(self.unique)
-		attributes[self.params[TupleComponents.t]] = str(self._t)
+		attributes[self.params[TupleComponents.ruia]] = self.ruia
+		attributes[self.params[TupleComponents.ruip]] = self.ruip
+		attributes[self.params[TupleComponents.ar]] = self.ar
+		attributes[self.params[TupleComponents.unique]] = self.unique
+		attributes[self.params[TupleComponents.t]] = self._t
 		return attributes
 
 	def create_assigned(self):
@@ -185,11 +185,11 @@ class DTuple(RtTuple):
 		"""Get the attributes of this tuplestring"""
 		attributes = {}
 		attributes[self.params[TupleComponents.type]] = self.tuple_type.value
-		attributes[self.params[TupleComponents.ruid]] = str(self.ruid)
-		attributes[self.params[TupleComponents.ruit]] = str(self.ruit_ref)
+		attributes[self.params[TupleComponents.ruid]] = self.ruid
+		attributes[self.params[TupleComponents.ruit]] = self.ruit_ref
 		attributes[self.params[TupleComponents.event]] = self.event.value
 		attributes[self.params[TupleComponents.event_reason]] = self.event_reason.value
-		attributes[self.params[TupleComponents.t]] = str(self.td)
+		attributes[self.params[TupleComponents.t]] = self.td
 		attributes[self.params[TupleComponents.replacements]] = self.replacements
 		return attributes
 	
@@ -222,15 +222,14 @@ class FTuple(RtTuple):
 		self.ruia = ruia
 		self.ta = ta
 		self.C = C
-
 	def get_attributes(self):
 		"""Get the attributes of this tuple"""
 		attributes = {}
-		attributes[self.params[TupleComponents.type]] = str(self.tuple_type)
-		attributes[self.params[TupleComponents.ruid]] = str(self.ruid)
-		attributes[self.params[TupleComponents.ruit]] = str(self.ruit_ref)
-		attributes[self.params[TupleComponents.ruia]] = str(self.ruia)
-		attributes[self.params[TupleComponents.ta]] = str(self.ta)
+		attributes[self.params[TupleComponents.type]] = self.tuple_type.value
+		attributes[self.params[TupleComponents.ruid]] = self.ruid
+		attributes[self.params[TupleComponents.ruit]] = self.ruit_ref
+		attributes[self.params[TupleComponents.ruia]] = self.ruia
+		attributes[self.params[TupleComponents.ta]] = self.ta
 		attributes[self.params[TupleComponents.C]] = self.C
 
 		return attributes
@@ -272,10 +271,10 @@ class NtoNTuple(RtTuple):
 		"""Get the attributes of this tuplestring"""
 		attributes = super().get_attributes()
 		attributes[self.params[TupleComponents.polarity]] = self.polarity
-		attributes[self.params[TupleComponents.r]] = str(self.relation)
+		attributes[self.params[TupleComponents.r]] = self.relation
 		attributes[self.params[TupleComponents.p_list]] = self.p_list
-		attributes[self.params[TupleComponents.rT]] = str(self.time_relation)
-		attributes[self.params[TupleComponents.tr]] = str(self.time)
+		attributes[self.params[TupleComponents.rT]] = self.time_relation
+		attributes[self.params[TupleComponents.tr]] = self.time
 		return attributes
 	
 class NtoRTuple(RtTuple):
@@ -308,11 +307,11 @@ class NtoRTuple(RtTuple):
 		"""Get the attributes of this tuplestring"""
 		attributes = super().get_attributes()
 		attributes[self.params[TupleComponents.polarity]] = self.polarity
-		attributes[self.params[TupleComponents.inst]] = str(self.inst)
-		attributes[self.params[TupleComponents.ruin]] = str(self.ruin)
-		attributes[self.params[TupleComponents.ruir]] = str(self.ruir)
-		attributes[self.params[TupleComponents.rT]] = str(self.time_relation)
-		attributes[self.params[TupleComponents.tr]] = str(self.time)
+		attributes[self.params[TupleComponents.inst]] = self.inst
+		attributes[self.params[TupleComponents.ruin]] = self.ruin
+		attributes[self.params[TupleComponents.ruir]] = self.ruir
+		attributes[self.params[TupleComponents.rT]] = self.time_relation
+		attributes[self.params[TupleComponents.tr]] = self.time
 		return attributes
 
 #TODO Use concepts
@@ -334,7 +333,7 @@ class NtoCTuple(RtTuple):
 	tuple_type = TupleType.NtoC
 	params = {**RtTuple.params, **enum_to_dict({TupleComponents.polarity, TupleComponents.r, TupleComponents.ruics, 
 											   TupleComponents.ruip, TupleComponents.code, TupleComponents.rT, TupleComponents.tr})}
-	
+	#TODO Change code to be bytecode
 	def __init__(self, ruit: Rui, polarity: bool, r: str, ruics: Rui, ruip: Rui, code: str, rT, tr: TempRef):
 		super().__init__(ruit)
 		self.polarity = polarity
@@ -349,12 +348,12 @@ class NtoCTuple(RtTuple):
 		"""Get the attributes of this tuplestring"""
 		attributes = super().get_attributes()
 		attributes[self.params[TupleComponents.polarity]] = self.polarity
-		attributes[self.params[TupleComponents.r]] = str(self.reason)
-		attributes[self.params[TupleComponents.ruics]] = str(self.ruics)
-		attributes[self.params[TupleComponents.ruip]] = str(self.ruip)
-		attributes[self.params[TupleComponents.code]] = str(self.code)
-		attributes[self.params[TupleComponents.rT]] = str(self.time_relation)
-		attributes[self.params[TupleComponents.tr]] = str(self.time)
+		attributes[self.params[TupleComponents.r]] = self.reason
+		attributes[self.params[TupleComponents.ruics]] = self.ruics
+		attributes[self.params[TupleComponents.ruip]] = self.ruip
+		attributes[self.params[TupleComponents.code]] = self.code
+		attributes[self.params[TupleComponents.rT]] = self.time_relation
+		attributes[self.params[TupleComponents.tr]] = self.time
 		return attributes
 
 # We use NtoDE instead of NtoI, and we use an instance for the identifying descriptor
@@ -390,9 +389,9 @@ class NtoDETuple(RtTuple):
 		"""Get the attributes of this tuplestring"""
 		attributes = super().get_attributes()
 		attributes[self.params[TupleComponents.polarity]] = self.polarity
-		attributes[self.params[TupleComponents.ruin]] = str(self.ruin)
-		attributes[self.params[TupleComponents.data]] = str(self.data)
-		attributes[self.params[TupleComponents.ruidt]] = str(self.ruidt)
+		attributes[self.params[TupleComponents.ruin]] = self.ruin
+		attributes[self.params[TupleComponents.data]] = self.data
+		attributes[self.params[TupleComponents.ruidt]] = self.ruidt
 		return attributes
 
 class NtoLackRTuple(RtTuple):
@@ -423,11 +422,11 @@ class NtoLackRTuple(RtTuple):
 	def get_attributes(self):
 		"""Get the attributes of this tuplestring"""
 		attributes = super().get_attributes()
-		attributes[self.params[TupleComponents.r]] = str(self.relation)
-		attributes[self.params[TupleComponents.ruip]] = str(self.ruip)
-		attributes[self.params[TupleComponents.ruir]] = str(self.ruir)
-		attributes[self.params[TupleComponents.rT]] = str(self.time_relation)
-		attributes[self.params[TupleComponents.tr]] = str(self.time)
+		attributes[self.params[TupleComponents.r]] = self.relation
+		attributes[self.params[TupleComponents.ruip]] = self.ruip
+		attributes[self.params[TupleComponents.ruir]] = self.ruir
+		attributes[self.params[TupleComponents.rT]] = self.time_relation
+		attributes[self.params[TupleComponents.tr]] = self.time
 		return attributes
 	
 """Mapping from tuple id to the corresponding tuple class"""

--- a/src/rt_core_v2/rttuple_factory.py
+++ b/src/rt_core_v2/rttuple_factory.py
@@ -1,0 +1,19 @@
+from rt_core_v2.ids_codes.Rui import Rui
+from rt_core_v2.rttuple import TupleComponents, TupleType, DTuple, type_to_class
+from rt_core_v2.metadata_accessory import RtChangeReason, TupleEventType
+
+
+#TODO Create testing that creates every tuple type using this function
+def rttuple_factory(tuple_arguments: dict, type: TupleType):
+    #DTuples should only be created in tandem with another tuple
+    if type is TupleType.D:
+        return None
+    try:
+        concrete_tuple = type_to_class[type](**tuple_arguments)
+        meta_tuple = DTuple(concrete_tuple.ruit, concrete_tuple.t, TupleEventType.INSERT, RtChangeReason.Belief)
+    except TypeError:
+        #TODO Log error where tuple has incorrect arguments
+        print(f"Incorrect arguments passed for tuple of type {type}")
+        return None
+
+    return concrete_tuple, meta_tuple

--- a/src/rt_core_v2/rttuple_formatter.py
+++ b/src/rt_core_v2/rttuple_formatter.py
@@ -11,7 +11,7 @@ from rt_core_v2.metadata_accessory import TupleEventType, RtChangeReason
 
 class RtTupleJSONEncoder(json.JSONEncoder):
 
-    encoded_classes = {Rui, TempRef}
+    encoded_classes = {Rui, TempRef, PorType, RuiStatus, TupleType}
 
     def __init__(self, *args, **kwargs):
         json.JSONEncoder.__init__(self, *args, **kwargs)

--- a/src/rt_core_v2/rttuple_formatter.py
+++ b/src/rt_core_v2/rttuple_formatter.py
@@ -51,7 +51,6 @@ json_entry_converter = {
     TupleComponents.ruin: JsonEntryConverter.str_to_rui,
     TupleComponents.ruir: JsonEntryConverter.str_to_rui,
     TupleComponents.ruics: JsonEntryConverter.str_to_rui,
-    TupleComponents.ruins: JsonEntryConverter.str_to_rui,
     TupleComponents.ruidt: JsonEntryConverter.str_to_rui,
     TupleComponents.t: JsonEntryConverter.str_to_temp,
     TupleComponents.td: JsonEntryConverter.str_to_temp,
@@ -88,3 +87,4 @@ def json_to_rttuple(tuple_json) -> RtTuple:
     tuple_class = type_to_class[tuple_dict[TupleComponents.type.value]]
     del tuple_dict[TupleComponents.type.value]
     return tuple_class(**tuple_dict)
+

--- a/src/rt_core_v2/rttuple_formatter.py
+++ b/src/rt_core_v2/rttuple_formatter.py
@@ -7,10 +7,30 @@ from rt_core_v2.rttuple import RtTuple, TupleComponents, TupleType, type_to_clas
 from rt_core_v2.ids_codes.Rui import Rui, TempRef
 from rt_core_v2.metadata_accessory import TupleEventType, RtChangeReason
 
-def rttuple_to_json(input_rttuples):
-    """Converts either a list or an RtTuple to a json object"""
-    return json.dumps(input_rttuples.get_str_attributes(), default=lambda o: o.toJSON() if hasattr(o, 'toJSON') else str(o))
 
+
+class RtTupleJSONEncoder(json.JSONEncoder):
+
+    encoded_classes = {Rui, TempRef}
+
+    def __init__(self, *args, **kwargs):
+        json.JSONEncoder.__init__(self, *args, **kwargs)
+    
+    def default(self, obj):
+        """If the object is an instance of an entry in encoded_classes then convert it to a string for the JSON"""
+        if any(isinstance(obj, cls) for cls in self.encoded_classes):
+            print(obj)
+            return str(obj)
+        else:
+            super().default(obj)
+
+
+def rttuple_to_json(input_rttuple: RtTuple):
+    """Convert an RtTuple to a json object"""
+    # return json.dumps(input_rttuple.get_attributes(), default=lambda o: o.toJSON() if hasattr(o, 'toJSON') else str(o))
+    return json.dumps(input_rttuple.get_attributes(), cls=RtTupleJSONEncoder)
+
+#TODO Swap this from an enum to a dictionary
 class RtTupleFormat(enum.Enum):
     """Enum mapping formats to functions to convert RtTuples into the format"""
     json_format = rttuple_to_json

--- a/src/rt_core_v2/rttuple_formatter.py
+++ b/src/rt_core_v2/rttuple_formatter.py
@@ -10,7 +10,7 @@ from rt_core_v2.metadata_accessory import TupleEventType, RtChangeReason
 
 
 class RtTupleJSONEncoder(json.JSONEncoder):
-
+    """Converts contents of RtTuples into a json representation"""
     encoded_classes = {Rui, TempRef, PorType, RuiStatus, TupleType}
 
     def __init__(self, *args, **kwargs):
@@ -19,7 +19,6 @@ class RtTupleJSONEncoder(json.JSONEncoder):
     def default(self, obj):
         """If the object is an instance of an entry in encoded_classes then convert it to a string for the JSON"""
         if any(isinstance(obj, cls) for cls in self.encoded_classes):
-            print(obj)
             return str(obj)
         else:
             super().default(obj)

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -60,8 +60,8 @@ def test_atuple_json():
     assert compare(formatted_a, expected_a)
 
     recreated_a = json_to_rttuple(formatted_a)
-    print(f"Original ATuple:  {a.get_str_attributes()}")
-    print(f"Recreated ATuple:  {recreated_a.get_str_attributes()}")
+    print(f"Original ATuple:  {a.get_attributes()}")
+    print(f"Recreated ATuple:  {recreated_a.get_attributes()}")
     assert a == recreated_a
 
 def test_dtuple_json():
@@ -74,8 +74,8 @@ def test_dtuple_json():
     assert compare(formatted_d, expected_d)
 
     recreated_d = json_to_rttuple(formatted_d)
-    print(f"Original DTuple:  {d.get_str_attributes()}")
-    print(f"Recreated DTuple:  {recreated_d.get_str_attributes()}")
+    print(f"Original DTuple:  {d.get_attributes()}")
+    print(f"Recreated DTuple:  {recreated_d.get_attributes()}")
     assert d == recreated_d
 
 def test_ftuple_json():
@@ -89,12 +89,13 @@ def test_ftuple_json():
     assert compare(formatted_f, expected_f)
 
     recreated_f = json_to_rttuple(formatted_f)
-    print(f"Original FTuple:  {f.get_str_attributes()}")
-    print(f"Recreated FTuple:  {recreated_f.get_str_attributes()}")
+    print(f"Original FTuple:  {f.get_attributes()}")
+    print(f"Recreated FTuple:  {recreated_f.get_attributes()}")
     assert f == recreated_f
 
 def test_nton_json():
     nton = NtoNTuple(ruit, polarity, relation, p_list, time_relation, time_1)
+    print(nton.get_attributes())
     formatted_nton = format_rttuple(nton)
     expected_nton = f"{{\"type\": \"{nton.tuple_type}\", \"ruit\": \"{ruit}\", \"polarity\": {str(polarity).lower()}, \"r\": \"{relation}\", \"p\": {jsonify_list(p_list)}, \"tr\": \"{time_1}\", \"rT\": \"{time_relation}\"}}"
 
@@ -104,8 +105,8 @@ def test_nton_json():
     assert compare(formatted_nton, expected_nton)
 
     recreated_nton = json_to_rttuple(formatted_nton)
-    print(f"Original NtonTuple:  {nton.get_str_attributes()}")
-    print(f"Recreated NtonTuple:  {recreated_nton.get_str_attributes()}")
+    print(f"Original NtonTuple:  {nton.get_attributes()}")
+    print(f"Recreated NtonTuple:  {recreated_nton.get_attributes()}")
     
     assert nton == recreated_nton
 
@@ -120,8 +121,8 @@ def test_ntor_json():
     assert compare(formatted_ntor, expected_ntor)
 
     recreated_ntor = json_to_rttuple(formatted_ntor)
-    print(f"Original NtorTuple:  {ntor.get_str_attributes()}")
-    print(f"Recreated NtorTuple:  {recreated_ntor.get_str_attributes()}")
+    print(f"Original NtorTuple:  {ntor.get_attributes()}")
+    print(f"Recreated NtorTuple:  {recreated_ntor.get_attributes()}")
     
     assert ntor == recreated_ntor
 
@@ -136,8 +137,8 @@ def test_ntoc_json():
     assert compare(formatted_ntoc, expected_ntoc)
 
     recreated_ntoc = json_to_rttuple(formatted_ntoc)
-    print(f"Original NtocTuple:  {ntoc.get_str_attributes()}")
-    print(f"Recreated NtocTuple:  {recreated_ntoc.get_str_attributes()}")
+    print(f"Original NtocTuple:  {ntoc.get_attributes()}")
+    print(f"Recreated NtocTuple:  {recreated_ntoc.get_attributes()}")
     
     assert ntoc == recreated_ntoc
 
@@ -152,8 +153,8 @@ def test_ntode_json():
     assert compare(formatted_ntode, expected_ntode)
 
     recreated_ntode = json_to_rttuple(formatted_ntode)
-    print(f"Original NtodeTuple:  {ntode.get_str_attributes()}")
-    print(f"Recreated NtodeTuple:  {recreated_ntode.get_str_attributes()}")
+    print(f"Original NtodeTuple:  {ntode.get_attributes()}")
+    print(f"Recreated NtodeTuple:  {recreated_ntode.get_attributes()}")
     
     assert ntode == recreated_ntode
 
@@ -169,7 +170,7 @@ def test_ntolackr_json():
     assert compare(formatted_ntolackr, expected_ntolackr)
 
     recreated_ntolackr = json_to_rttuple(formatted_ntolackr)
-    print(f"Original NtolackrTuple:  {ntolackr.get_str_attributes()}")
-    print(f"Recreated NtolackrTuple:  {recreated_ntolackr.get_str_attributes()}")
+    print(f"Original NtolackrTuple:  {ntolackr.get_attributes()}")
+    print(f"Recreated NtolackrTuple:  {recreated_ntolackr.get_attributes()}")
 
     assert ntolackr == recreated_ntolackr

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -21,15 +21,14 @@ ruics = Rui()
 ruir = Rui()
 ruin = Rui()
 ruidt = Rui()
-ruins = Rui()
 
 time_1 = TempRef()
 event = TupleEventType.INSERT
 reason = RtChangeReason.BELIEF
-replacements = [ruins, ruidt, ruin]
+replacements = [ruin, ruidt, ruin]
 polarity = False
 relation = "part of"
-p_list = [ruid, ruins]
+p_list = [ruid, ruin]
 time_relation = "at"
 code = "code insert"
 inst = "instance of"
@@ -143,9 +142,9 @@ def test_ntoc_json():
     assert ntoc == recreated_ntoc
 
 def test_ntode_json():
-    ntode = NtoDETuple(ruit, polarity, ruin, ruins, data, ruidt)
+    ntode = NtoDETuple(ruit, polarity, ruin, data, ruidt)
     formatted_ntode = format_rttuple(ntode)
-    expected_ntode = f"{{\"ruit\": \"{ruit}\", \"type\": \"{ntode.tuple_type}\", \"polarity\": {str(polarity).lower()}, \"ruin\": \"{ruin}\", \"ruins\": \"{ruins}\", \"ruidt\": \"{ruidt}\", \"data\": \"{data}\"}}"
+    expected_ntode = f"{{\"ruit\": \"{ruit}\", \"type\": \"{ntode.tuple_type}\", \"polarity\": {str(polarity).lower()}, \"ruin\": \"{ruin}\", \"ruidt\": \"{ruidt}\", \"data\": \"{data}\"}}"
 
     print("Ntoctuple Expected:  \n" + expected_ntode)
     print("Ntoctuple Processed:  \n" + formatted_ntode)


### PR DESCRIPTION
Larger Changes:
- Created rts_store.py
- Created RtStore abstract class that contains essential functions for an Rt storage system
- Created framework for the TupleQuery class based on the java code. Incomplete, as newer tuples need to be filled in and parameters need to be updated to match changes to the tuple structure
- Added RtTupleJSONEncoder to ensure non-JSON compatible components of the tuples are converted to JSON compatible types
- Added generic factory method that produces a D-Tuple alongside and corresponding to a tuple of a different type.

Smaller Changes:
- Removed toJson functions, as it lead to unneeded coupling
- Added more type hints
- Changed get_str_attributes to just get_attributes
- Added default parameter value generation for some Ruis
- Corrected tests to work with edits to function names