### PR TITLE
Split A- and D- Tuples

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,9 @@ authors = [
 description = "Python implementation of Referent Tracking 2.0"
 readme = "README.md"
 requires-python = ">=3.11"
+dependencies = [
+  "uuid6~=2024.1.12", 
+]
 
 [tool.pytest.ini_options]
 pythonpath = [

--- a/src/rt_core_v2/factory.py
+++ b/src/rt_core_v2/factory.py
@@ -1,4 +1,4 @@
-from rt_core_v2.rttuple import TupleType, DTuple, TupleComponents, RuiStatus, PorType, TempRef, type_to_class
+from rt_core_v2.rttuple import TupleType, DiTuple, DcTuple, TupleComponents, RuiStatus, PorType, TempRef, type_to_class
 from rt_core_v2.metadata import RtChangeReason, TupleEventType
 from rt_core_v2.ids_codes.rui import Rui
 
@@ -18,7 +18,7 @@ def rttuple_factory(tuple_arguments: dict, type: TupleType, t: TempRef, event: T
         return None
     try:
         concrete_tuple = type_to_class[type](**tuple_arguments)
-        meta_tuple = DTuple(
+        meta_tuple = DcTuple(
             concrete_tuple.rui,
             t,
             event, 

--- a/src/rt_core_v2/factory.py
+++ b/src/rt_core_v2/factory.py
@@ -34,10 +34,10 @@ def rttuple_factory(tuple_arguments: dict, type: TupleType, t: TempRef, event: T
     return concrete_tuple, meta_tuple
 
 #TODO Make a factory for each tuple that calls rttuple_factory
-def create_atuple(rui: Rui=None, ruia: Rui=None, ruin: Rui=None, ar: RuiStatus=RuiStatus.assigned, unique: PorType=PorType.singular, t: TempRef=None, event=TupleEventType.INSERT, event_reason=RtChangeReason.BELIEF, replacements=[], author=None):
-    atuple_arguments = {TupleComponents.rui:rui, TupleComponents.ruia:ruia, TupleComponents.ruin:ruin, TupleComponents.ar:ar, TupleComponents.unique:unique, TupleComponents.t:t}
+def create_antuple(rui: Rui=None, ruia: Rui=None, ruin: Rui=None, ar: RuiStatus=RuiStatus.assigned, unique: PorType=PorType.singular, t: TempRef=None, event=TupleEventType.INSERT, event_reason=RtChangeReason.BELIEF, replacements=[], author=None):
+    antuple_arguments = {TupleComponents.rui:rui, TupleComponents.ruia:ruia, TupleComponents.ruin:ruin, TupleComponents.ar:ar, TupleComponents.unique:unique, TupleComponents.t:t}
     author = author if author else ruia
-    return rttuple_factory(atuple_arguments, TupleType.AN, t, event, event_reason, replacements, author)
+    return rttuple_factory(antuple_arguments, TupleType.AN, t, event, event_reason, replacements, author)
 
 def create_ftuple(rui:Rui=None, ruid:Rui=None, ta:TempRef=None, C:float=1.0, ruitn:Rui=None, t: TempRef=None, event=TupleEventType.INSERT, event_reason=RtChangeReason.BELIEF, replacements=[], author=None):
     ftuple_arguments = {TupleComponents.rui:rui, TupleComponents.ruid:ruid, TupleComponents.ta:ta, TupleComponents.ruitn:ruitn, TupleComponents.C:C}

--- a/src/rt_core_v2/factory.py
+++ b/src/rt_core_v2/factory.py
@@ -37,7 +37,7 @@ def rttuple_factory(tuple_arguments: dict, type: TupleType, t: TempRef, event: T
 def create_atuple(rui: Rui=None, ruia: Rui=None, ruin: Rui=None, ar: RuiStatus=RuiStatus.assigned, unique: PorType=PorType.singular, t: TempRef=None, event=TupleEventType.INSERT, event_reason=RtChangeReason.BELIEF, replacements=[], author=None):
     atuple_arguments = {TupleComponents.rui:rui, TupleComponents.ruia:ruia, TupleComponents.ruin:ruin, TupleComponents.ar:ar, TupleComponents.unique:unique, TupleComponents.t:t}
     author = author if author else ruia
-    return rttuple_factory(atuple_arguments, TupleType.A, t, event, event_reason, replacements, author)
+    return rttuple_factory(atuple_arguments, TupleType.AN, t, event, event_reason, replacements, author)
 
 def create_ftuple(rui:Rui=None, ruid:Rui=None, ta:TempRef=None, C:float=1.0, ruitn:Rui=None, t: TempRef=None, event=TupleEventType.INSERT, event_reason=RtChangeReason.BELIEF, replacements=[], author=None):
     ftuple_arguments = {TupleComponents.rui:rui, TupleComponents.ruid:ruid, TupleComponents.ta:ta, TupleComponents.ruitn:ruitn, TupleComponents.C:C}

--- a/src/rt_core_v2/formatter.py
+++ b/src/rt_core_v2/formatter.py
@@ -104,6 +104,7 @@ json_entry_converter = {
     TupleComponents.ruidt: JsonEntryConverter.str_to_rui,
     TupleComponents.ruit: JsonEntryConverter.str_to_rui,
     TupleComponents.ruitn: JsonEntryConverter.str_to_rui,
+    TupleComponents.ruio: JsonEntryConverter.str_to_rui,
     TupleComponents.t: JsonEntryConverter.process_temp_ref,
     TupleComponents.ta: JsonEntryConverter.process_temp_ref,
     TupleComponents.tr: JsonEntryConverter.process_temp_ref,

--- a/src/rt_core_v2/formatter.py
+++ b/src/rt_core_v2/formatter.py
@@ -11,7 +11,8 @@ from rt_core_v2.rttuple import (
     type_to_class,
     RuiStatus,
     PorType,
-    AttributesVisitor
+    AttributesVisitor,
+    RtTupleVisitor,
 )
 from rt_core_v2.ids_codes.rui import Rui, TempRef
 from rt_core_v2.metadata import TupleEventType, RtChangeReason
@@ -32,22 +33,27 @@ class RtTupleJSONEncoder(json.JSONEncoder):
         else:
             super().default(obj)
 
-get_attributes = AttributesVisitor()
-def rttuple_to_json(input_rttuple: RtTuple):
-    """Convert an RtTuple to a json object"""
-    return json.dumps(input_rttuple.accept(get_attributes), cls=RtTupleJSONEncoder)
+class ToJsonVisitor(RtTupleVisitor):
+    """
+    Converts an RtTuple into a JSON
+
+    Attributes:
+    get_attributes -- Visitor to retrieve a tuple's attributes in a formatted manner
+    """
+    get_attributes = AttributesVisitor()
+    def visit(self, host: RtTuple):
+        return json.dumps(host.accept(self.get_attributes), cls=RtTupleJSONEncoder)
 
 
 # TODO Swap this from an enum to a dictionary
 class RtTupleFormat(enum.Enum):
     """Enum mapping formats to functions to convert RtTuples into the format"""
-
-    json_format = rttuple_to_json
+    json_format = ToJsonVisitor()
 
 
 def format_rttuple(tuple: RtTuple, format: RtTupleFormat = RtTupleFormat.json_format):
     """Convert the rttuple to the specified format"""
-    return format(tuple)
+    return tuple.accept(format.value)
 
 
 def write_tuples(

--- a/src/rt_core_v2/ids_codes/rui.py
+++ b/src/rt_core_v2/ids_codes/rui.py
@@ -55,7 +55,7 @@ class TempRef:
         return self.__dict__ == other.__dict__
 
 class Relationship:
-
+    
     def __init__(self, uri: str, ontology: Rui):
         self.uri = uri
         self.ontology = ontology

--- a/src/rt_core_v2/metadata.py
+++ b/src/rt_core_v2/metadata.py
@@ -93,7 +93,6 @@ description_dict = {
     RtChangeReason.BELIEF: "the entity making this update to the system had a change in belief about what is true of reality and is making this update to reflect its change in belief.",
     RtChangeReason.REALITY: "the entity making this update to the system recognized that reality has changed and is making this update to reflect new reality",
     RtChangeReason.RELEVANCE: "the entity making this update to the system changed what it deems relevant to the purposes of the system and is making this update to reflect this change in relevance",
-    RtChangeReason.MISTAKE: "the entity making this update recognized a mistake and is updating the system to correct it",
     RtChangeReason.A1: "The RUI that denotes the primary referent of the tuple, typically the ruin parameter, does not refer to any existing entity in reality after all",
     RtChangeReason.A2: "The RUI that denotes the primary referent of the tuple, typically the ruin parameter, refers to two or more numerically distinct portions of reality",
     RtChangeReason.A3: "The RUI that denotes the primary referent of the tuple, typically the ruin parameter, is not the only RUI in the RTS that refers to this portion of reality and the adjudication is to retire and replace it",

--- a/src/rt_core_v2/persist/rts_store.py
+++ b/src/rt_core_v2/persist/rts_store.py
@@ -32,7 +32,7 @@ class TupleQuery:
 
     # Tuples types are filtered out not by the query sharing qualiting that the tuple has, but by the query having any quality that the tuple type does not
 
-    def match_atuple(self):
+    def match_antuple(self):
         if self.types and TupleType.AN not in self.types:
             return False
         if (

--- a/src/rt_core_v2/persist/rts_store.py
+++ b/src/rt_core_v2/persist/rts_store.py
@@ -33,7 +33,7 @@ class TupleQuery:
     # Tuples types are filtered out not by the query sharing qualiting that the tuple has, but by the query having any quality that the tuple type does not
 
     def match_atuple(self):
-        if self.types and TupleType.A not in self.types:
+        if self.types and TupleType.AN not in self.types:
             return False
         if (
             self.relationship_rui

--- a/src/rt_core_v2/rttuple.py
+++ b/src/rt_core_v2/rttuple.py
@@ -48,6 +48,7 @@ class PorType(ValueEnum):
 class TupleComponents(enum.Enum):
     ruit = "ruit"
     ruitn = "ruitn"
+    ruio = 'ruio'
     type = "type"
     ar = "ar"
     ruia = "ruia"
@@ -56,7 +57,6 @@ class TupleComponents(enum.Enum):
     ruid = "ruid"
     event = "event"
     event_reason = "event_reason"
-    td = "td"
     replacements = "replacements"
     ta = "ta"
     C = "C"
@@ -136,6 +136,7 @@ class ANTuple(RtTuple):
 
 
 #TODO Add ontology field
+#TODO Figure out the process for inserting an ontology. Is it just an instance that has an ntode tuple linking to the website?
 @dataclass
 class ARTuple(RtTuple):
     """Referent Tracking assignment tuple that registers assignment of an RUI to a PoR
@@ -157,12 +158,14 @@ class ARTuple(RtTuple):
                 TupleComponents.t,
                 TupleComponents.ruia,
                 TupleComponents.unique,
-                TupleComponents.ruin,
+                TupleComponents.ruir,
+                TupleComponents.ruio,
             }
         ),
     }
     ruia: Rui = field(default_factory=Rui)
-    ruin: Rui = field(default_factory=Rui)
+    ruir: Rui = field(default_factory=Rui)
+    ruio: Rui = field(default_factory=Rui)
     ar: RuiStatus = RuiStatus.assigned
     unique: PorType = PorType.singular
     t: TempRef = field(default_factory=TempRef)
@@ -466,10 +469,11 @@ class AttributesVisitor(RtTupleVisitor):
         attributes[host.params[TupleComponents.t]] = host.t
         return attributes
     
-    def visit_ar(self, host:ANTuple):
+    def visit_ar(self, host:ARTuple):
         attributes = {}
         attributes[host.params[TupleComponents.ruia]] = host.ruia
-        attributes[host.params[TupleComponents.ruin]] = host.ruin
+        attributes[host.params[TupleComponents.ruir]] = host.ruir
+        attributes[host.params[TupleComponents.ruio]] = host.ruio
         attributes[host.params[TupleComponents.ar]] = host.ar
         attributes[host.params[TupleComponents.unique]] = host.unique
         attributes[host.params[TupleComponents.t]] = host.t

--- a/src/rt_core_v2/rttuple.py
+++ b/src/rt_core_v2/rttuple.py
@@ -25,7 +25,8 @@ class RuiStatus(ValueEnum):
 
 
 class TupleType(ValueEnum):
-    A = "A"
+    AR = "AR"
+    AN = "AN"
     D = "D"
     F = "F"
     NtoDE = "NtoDE"
@@ -102,18 +103,52 @@ class RtTuple(ABC):
         return visitor.visit(self)
 
 @dataclass
-class ATuple(RtTuple):
+class ANTuple(RtTuple):
     """Referent Tracking assignment tuple that registers assignment of an RUI to a PoR
 
     Attributes:
     ar -- The status of ruin
     ruin -- The Rui that is being assigned for the first time
-    ruia -- The Rui of the author of this ATuple
+    ruia -- The Rui of the author of this ANTuple
     unique -- Asserts whether this is a non-repeatable or repeatable portion of reality
-    t -- The time of the creation of the ATuple
+    t -- The time of the creation of the ANTuple
     """
 
-    tuple_type: ClassVar[TupleType] = TupleType.A
+    tuple_type: ClassVar[TupleType] = TupleType.AN
+    params: ClassVar[dict[TupleComponents, str]] = {
+        **RtTuple.params,
+        **enum_to_dict(
+            {
+                TupleComponents.ar,
+                TupleComponents.t,
+                TupleComponents.ruia,
+                TupleComponents.unique,
+                TupleComponents.ruin,
+            }
+        ),
+    }
+    ruia: Rui = field(default_factory=Rui)
+    ruin: Rui = field(default_factory=Rui)
+    ar: RuiStatus = RuiStatus.assigned
+    unique: PorType = PorType.singular
+    t: TempRef = field(default_factory=TempRef)
+
+
+
+#TODO Add ontology field
+@dataclass
+class ARTuple(RtTuple):
+    """Referent Tracking assignment tuple that registers assignment of an RUI to a PoR
+
+    Attributes:
+    ar -- The status of ruin
+    ruin -- The Rui that is being assigned for the first time
+    ruia -- The Rui of the author of this ARTuple
+    unique -- Asserts whether this is a non-repeatable or repeatable portion of reality
+    t -- The time of the creation of the ARTuple
+    """
+
+    tuple_type: ClassVar[TupleType] = TupleType.AR
     params: ClassVar[dict[TupleComponents, str]] = {
         **RtTuple.params,
         **enum_to_dict(
@@ -379,7 +414,8 @@ class NtoLackRTuple(RtTuple):
 
 """Mapping from tuple id to the corresponding tuple class"""
 type_to_class = {
-    TupleType.A: ATuple,
+    TupleType.AN: ANTuple,
+    TupleType.AR: ARTuple,
     TupleType.D: DTuple,
     TupleType.F: FTuple,
     TupleType.NtoDE: NtoDETuple,
@@ -401,8 +437,10 @@ class AttributesVisitor(RtTupleVisitor):
             host.params[TupleComponents.type]: host.tuple_type,
         }
         match host.tuple_type:
-            case TupleType.A:
-                attributes |= self.visit_a(host)
+            case TupleType.AN:
+                attributes |= self.visit_an(host)
+            case TupleType.AR:
+                attributes |= self.visit_ar(host)
             case TupleType.D:
                 attributes |= self.visit_d(host)
             case TupleType.F:
@@ -419,7 +457,16 @@ class AttributesVisitor(RtTupleVisitor):
                 attributes |= self.visit_ntolackr(host)
         return attributes
 
-    def visit_a(self, host:ATuple):
+    def visit_an(self, host:ANTuple):
+        attributes = {}
+        attributes[host.params[TupleComponents.ruia]] = host.ruia
+        attributes[host.params[TupleComponents.ruin]] = host.ruin
+        attributes[host.params[TupleComponents.ar]] = host.ar
+        attributes[host.params[TupleComponents.unique]] = host.unique
+        attributes[host.params[TupleComponents.t]] = host.t
+        return attributes
+    
+    def visit_ar(self, host:ANTuple):
         attributes = {}
         attributes[host.params[TupleComponents.ruia]] = host.ruia
         attributes[host.params[TupleComponents.ruin]] = host.ruin

--- a/src/rt_core_v2/rttuple.py
+++ b/src/rt_core_v2/rttuple.py
@@ -264,16 +264,12 @@ class FTuple(RtTuple):
         **RtTuple.params,
         **enum_to_dict(
             {
-                TupleComponents.ruid,
-                TupleComponents.ta,
                 TupleComponents.C,
                 TupleComponents.ruitn,
             }
         ),
     }
-    ruid: Rui = field(default_factory=Rui)
     ruitn: Rui = field(default_factory=Rui)
-    ta: TempRef = field(default_factory=TempRef)
     C: float = 1.0
 
 
@@ -546,9 +542,7 @@ class AttributesVisitor(RtTupleVisitor):
 
     def visit_f(self, host:FTuple):
         attributes = {}
-        attributes[host.params[TupleComponents.ruid]] = host.ruid
         attributes[host.params[TupleComponents.ruitn]] = host.ruitn
-        attributes[host.params[TupleComponents.ta]] = host.ta
         attributes[host.params[TupleComponents.C]] = host.C
         return attributes
 

--- a/src/rt_core_v2/rttuple.py
+++ b/src/rt_core_v2/rttuple.py
@@ -429,6 +429,10 @@ type_to_class = {
 }
 
 class AttributesVisitor(RtTupleVisitor):
+    """
+    Visitor that converts a tuple's representation to a dictionary 
+    mapping the TupleComponent entry type to the value of the entry
+    """
     def __init__(self):
         super().__init__()
 

--- a/tests/test_atuple.py
+++ b/tests/test_atuple.py
@@ -1,10 +1,10 @@
-from rt_core_v2.rttuple import ATuple
+from rt_core_v2.rttuple import ANTuple
 
 from rt_core_v2.ids_codes.rui import Rui
 from datetime import datetime, timezone
 
 
-def print_ATuple(a):
+def print_ANTuple(a):
     print("tuple information:")
     print("\trui: the rui that denotes tuple itself", str(a.rui.uuid))
     print("\truin: rui that was assigned to some PoR", str(a.ruin.uuid))
@@ -23,15 +23,15 @@ def print_ATuple(a):
 a = Rui()
 
 x = Rui()
-y = ATuple(x)
-print_ATuple(y)
+y = ANTuple(x)
+print_ANTuple(y)
 
 q = Rui()
-z = ATuple(q, ruia=a, unique="+SU", ar="R")
-print_ATuple(z)
+z = ANTuple(q, ruia=a, unique="+SU", ar="R")
+print_ANTuple(z)
 
 s = Rui()
-w = ATuple(s, ruia=a, unique="+SU")
-print_ATuple(w)
+w = ANTuple(s, ruia=a, unique="+SU")
+print_ANTuple(w)
 
 print(type(datetime.now(timezone.utc)))

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -39,7 +39,6 @@ ruidt = Rui()
 ruio = Rui()
 rui = Rui()
 
-print("HIIII")
 get_attributes = AttributesVisitor()
 
 time_1 = TempRef()

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -138,9 +138,9 @@ def test_dctuple_json():
 
 def test_ftuple_json():
     C = 0.753
-    f = FTuple(ruid=ruid, ruitn=ruitn, ta=time_1, C=C, rui=rui)
+    f = FTuple(ruitn=ruitn, C=C, rui=rui)
     formatted_f = format_rttuple(f)
-    expected_f = f'{{"type": "{f.tuple_type}", "ruid": "{ruid}", "ruitn": "{ruitn}", "ta": "{time_1}", "C": {C}, "rui": "{rui}"}}'
+    expected_f = f'{{"type": "{f.tuple_type}", "ruitn": "{ruitn}", "C": {C}, "rui": "{rui}"}}'
     print("Ftuple Expected:  \n" + expected_f)
     print("Ftuple Processed:  \n" + formatted_f)
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -4,7 +4,8 @@ from rt_core_v2.ids_codes.rui import Rui, TempRef
 from rt_core_v2.rttuple import (
     ANTuple,
     ARTuple,
-    DTuple,
+    DiTuple,
+    DcTuple,
     FTuple,
     NtoNTuple,
     NtoRTuple,
@@ -42,7 +43,7 @@ print("HIIII")
 get_attributes = AttributesVisitor()
 
 time_1 = TempRef()
-event = TupleEventType.INSERT
+event = TupleEventType.REVALIDATE
 reason = RtChangeReason.BELIEF
 replacements = [ruin, ruidt, ruin]
 polarity = False
@@ -103,13 +104,12 @@ def test_artuple_json():
     assert a == recreated_a
 
 
-def test_dtuple_json():
-    d = DTuple(
-        ruit=ruit, t=time_1, event=TupleEventType.INSERT, event_reason=RtChangeReason.BELIEF, ruid=ruid, replacements=replacements, rui=rui
+def test_dituple_json():
+    d = DiTuple(
+        ruit=ruit, t=time_1, event_reason=RtChangeReason.BELIEF, ruid=ruid, rui=rui, ruia=ruia, ta=time_1
     )
     formatted_d = format_rttuple(d)
-    replacements_repr = jsonify_list(replacements)
-    expected_d = f'{{"type": "{d.tuple_type}", "ruid": "{ruid}", "ruit": "{ruit}", "t": "{time_1}", "event": {event}, "event_reason": {reason}, "replacements": {replacements_repr}, "rui": "{rui}"}}'
+    expected_d = f'{{"type": "{d.tuple_type}", "ruid": "{ruid}", "ruit": "{ruit}", "t": "{time_1}", "event_reason": {reason}, "rui": "{rui}", "ruia": "{ruia}", "ta": "{time_1}"}}'
     print("Dtuple Expected:  \n" + expected_d)
     print("Dtuple Processed:  \n" + formatted_d)
     assert compare(formatted_d, expected_d)
@@ -117,6 +117,22 @@ def test_dtuple_json():
     recreated_d = json_to_rttuple(formatted_d)
     print(f"Original DTuple:  {d.accept(get_attributes)}")
     print(f"Recreated DTuple:  {recreated_d.accept(get_attributes)}")
+    assert d == recreated_d
+
+def test_dctuple_json():
+    d = DcTuple(
+        ruit=ruit, t=time_1, event=TupleEventType.REVALIDATE, event_reason=RtChangeReason.BELIEF, ruid=ruid, replacements=replacements, rui=rui
+    )
+    formatted_d = format_rttuple(d)
+    replacements_repr = jsonify_list(replacements)
+    expected_d = f'{{"type": "{d.tuple_type}", "ruid": "{ruid}", "ruit": "{ruit}", "t": "{time_1}", "event": {event}, "event_reason": {reason}, "replacements": {replacements_repr}, "rui": "{rui}"}}'
+    print("Dctuple Expected:  \n" + expected_d)
+    print("Dctuple Processed:  \n" + formatted_d)
+    assert compare(formatted_d, expected_d)
+
+    recreated_d = json_to_rttuple(formatted_d)
+    print(f"Original DcTuple:  {d.accept(get_attributes)}")
+    print(f"Recreated DcTuple:  {recreated_d.accept(get_attributes)}")
     assert d == recreated_d
 
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -3,6 +3,7 @@ import json
 from rt_core_v2.ids_codes.rui import Rui, TempRef
 from rt_core_v2.rttuple import (
     ANTuple,
+    ARTuple,
     DTuple,
     FTuple,
     NtoNTuple,
@@ -34,6 +35,7 @@ ruics = Rui()
 ruir = Rui()
 ruin = Rui()
 ruidt = Rui()
+ruio = Rui()
 rui = Rui()
 
 print("HIIII")
@@ -84,6 +86,20 @@ def test_antuple_json():
     recreated_a = json_to_rttuple(formatted_a)
     print(f"Original ANTuple:  {a.accept(get_attributes)}")
     print(f"Recreated ANTuple:  {recreated_a.accept(get_attributes)}")
+    assert a == recreated_a
+
+
+def test_artuple_json():
+    a = ARTuple(rui=rui, ruia=ruia, ruir=ruir, ruio=ruio)
+    formatted_a = format_rttuple(a)
+    expected_a = f'{{"rui": "{rui}", "type": "{a.tuple_type}", "ruia": "{ruia}", "ruir": "{ruir}", "ruio": "{ruio}", "unique": "{a.unique}", "ar": "{a.ar}", "t": "{a.t}"}}'
+    print("ARtuple Expected:  \n" + expected_a)
+    print("ARtuple Processed:  \n" + formatted_a)
+    assert compare(formatted_a, expected_a)
+
+    recreated_a = json_to_rttuple(formatted_a)
+    print(f"Original ARTuple:  {a.accept(get_attributes)}")
+    print(f"Recreated ARTuple:  {recreated_a.accept(get_attributes)}")
     assert a == recreated_a
 
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -2,7 +2,7 @@ import json
 
 from rt_core_v2.ids_codes.rui import Rui, TempRef
 from rt_core_v2.rttuple import (
-    ATuple,
+    ANTuple,
     DTuple,
     FTuple,
     NtoNTuple,
@@ -73,17 +73,17 @@ def compare(formatted, expected):
 """All of the below tuple tests first check whether converting from a tuple object to a json functions correclty then checks whether the reverse change is correct."""
 
 
-def test_atuple_json():
-    a = ATuple(rui=rui, ruia=ruia, ruin=ruin)
+def test_antuple_json():
+    a = ANTuple(rui=rui, ruia=ruia, ruin=ruin)
     formatted_a = format_rttuple(a)
     expected_a = f'{{"ruin": "{ruin}", "ruia": "{ruia}", "rui": "{rui}", "type": "{a.tuple_type}", "unique": "{a.unique}", "ar": "{a.ar}", "t": "{a.t}"}}'
-    print("Atuple Expected:  \n" + expected_a)
-    print("Atuple Processed:  \n" + formatted_a)
+    print("ANtuple Expected:  \n" + expected_a)
+    print("ANtuple Processed:  \n" + formatted_a)
     assert compare(formatted_a, expected_a)
 
     recreated_a = json_to_rttuple(formatted_a)
-    print(f"Original ATuple:  {a.accept(get_attributes)}")
-    print(f"Recreated ATuple:  {recreated_a.accept(get_attributes)}")
+    print(f"Original ANTuple:  {a.accept(get_attributes)}")
+    print(f"Recreated ANTuple:  {recreated_a.accept(get_attributes)}")
     assert a == recreated_a
 
 

--- a/tests/test_meta_tuple.py
+++ b/tests/test_meta_tuple.py
@@ -1,5 +1,5 @@
 from rt_core_v2.ids_codes import rui
-from rt_core_v2.rttuple import DTuple, FTuple, ANTuple
+from rt_core_v2.rttuple import DcTuple, FTuple, ANTuple
 from rt_core_v2.metadata import TupleEventType, RtChangeReason
 
 
@@ -45,9 +45,9 @@ x = ANTuple(s, ruia=a)
 # the entity registering the tuples in the RTS
 dr = rui.Rui()
 # metadata or D tuple for w (ANTuple)
-dt1 = DTuple(ruid=a, ruit=a, event=TupleEventType.INSERT, event_reason=RtChangeReason.REALITY)
+dt1 = DcTuple(ruid=a, ruit=a, event=TupleEventType.INSERT, event_reason=RtChangeReason.REALITY)
 # metadata or D tuple for x (ANTuple)
-dt2 = DTuple(ruid=a, ruit=s, event=TupleEventType.INSERT, event_reason=RtChangeReason.REALITY)
+dt2 = DcTuple(ruid=a, ruit=s, event=TupleEventType.INSERT, event_reason=RtChangeReason.REALITY)
 
 print_d_tuple(dt1)
 print_d_tuple(dt2)

--- a/tests/test_meta_tuple.py
+++ b/tests/test_meta_tuple.py
@@ -23,14 +23,10 @@ def print_d_tuple(dt):
 
 def print_f_tuple(ft):
     print(
-        "<",
-        ft.ruid.uuid,
-        "> has confidence level '",
+        "confidence level '",
         ft.C,
         "' in tuple <",
         ft.ruitn.uuid,
-        "> at ",
-        ft.ta,
     )
     print("\ttuple rui: ", ft.rui.uuid)
 
@@ -54,7 +50,7 @@ print_d_tuple(dt2)
 
 # now create an FTuple for each ANTuple.  ruitn, ruia, ta, C, ruit=None):
 # actually at the moment this is a mistake. ANTuples won't have associated FTuples. We just need to build the other template types first.
-ft1 = FTuple(ruitn=w.rui, ruid=a, ta=rui.TempRef(), C=0.76)
-ft2 = FTuple(ruitn=x.rui, ruid=a, ta=rui.TempRef(), C=0.5)
+ft1 = FTuple(ruitn=w.rui, C=0.76)
+ft2 = FTuple(ruitn=x.rui, C=0.5)
 print_f_tuple(ft1)
 print_f_tuple(ft2)

--- a/tests/test_meta_tuple.py
+++ b/tests/test_meta_tuple.py
@@ -1,5 +1,5 @@
 from rt_core_v2.ids_codes import rui
-from rt_core_v2.rttuple import DTuple, FTuple, ATuple
+from rt_core_v2.rttuple import DTuple, FTuple, ANTuple
 from rt_core_v2.metadata import TupleEventType, RtChangeReason
 
 
@@ -35,25 +35,25 @@ def print_f_tuple(ft):
     print("\ttuple rui: ", ft.rui.uuid)
 
 
-# create two ATuples with a = rui of person assigning rui to things
+# create two ANTuples with a = rui of person assigning rui to things
 a = rui.Rui()
 s = rui.Rui()
-w = ATuple(a, ruia=a)
-x = ATuple(s, ruia=a)
+w = ANTuple(a, ruia=a)
+x = ANTuple(s, ruia=a)
 
-# create two D tuples for each ATuple
+# create two D tuples for each ANTuple
 # the entity registering the tuples in the RTS
 dr = rui.Rui()
-# metadata or D tuple for w (ATuple)
+# metadata or D tuple for w (ANTuple)
 dt1 = DTuple(ruid=a, ruit=a, event=TupleEventType.INSERT, event_reason=RtChangeReason.REALITY)
-# metadata or D tuple for x (ATuple)
+# metadata or D tuple for x (ANTuple)
 dt2 = DTuple(ruid=a, ruit=s, event=TupleEventType.INSERT, event_reason=RtChangeReason.REALITY)
 
 print_d_tuple(dt1)
 print_d_tuple(dt2)
 
-# now create an FTuple for each ATuple.  ruitn, ruia, ta, C, ruit=None):
-# actually at the moment this is a mistake. ATuples won't have associated FTuples. We just need to build the other template types first.
+# now create an FTuple for each ANTuple.  ruitn, ruia, ta, C, ruit=None):
+# actually at the moment this is a mistake. ANTuples won't have associated FTuples. We just need to build the other template types first.
 ft1 = FTuple(ruitn=w.rui, ruid=a, ta=rui.TempRef(), C=0.76)
 ft2 = FTuple(ruitn=x.rui, ruid=a, ta=rui.TempRef(), C=0.5)
 print_f_tuple(ft1)

--- a/tests/test_ntoxtuple.py
+++ b/tests/test_ntoxtuple.py
@@ -1,9 +1,9 @@
 from rt_core_v2.ids_codes import rui
-from rt_core_v2.rttuple import ATuple, NtoRTuple, NtoNTuple, RuiStatus
+from rt_core_v2.rttuple import ANTuple, NtoRTuple, NtoNTuple, RuiStatus
 
 
-def print_ATuple(a):
-    print("A tuple information:")
+def print_ANTuple(a):
+    print("AN tuple information:")
     print("\trui: the rui that denotes tuple itself", str(a.rui.uuid))
     print("\truin: rui that was assigned to some PoR", str(a.ruin.uuid))
     print("\tis ruin reserved? ", a.ar)
@@ -79,27 +79,27 @@ a = rui.Rui()
 h = rui.Rui()
 # Rui that stands for interval over which author has been instance of human being
 tr1 = rui.Rui()
-k = ATuple(tr1, ruia=a)
+k = ANTuple(tr1, ruia=a)
 
 NtoRTuple = NtoRTuple(polarity=True, inst="part of", ruin=a, ruir=h, tr=rui.TempRef())
 print_NtoRTuple_tuple(NtoRTuple)
 
 # let x be the RUI standing for Kuala Lumpur
 x = rui.Rui()
-y = ATuple(x)
-print_ATuple(y)
+y = ANTuple(x)
+print_ANTuple(y)
 
 q = rui.Rui()
-z = ATuple(q, ruia=a, ar=RuiStatus.reserved)
-print_ATuple(z)
+z = ANTuple(q, ruia=a, ar=RuiStatus.reserved)
+print_ANTuple(z)
 
 # let s be the RUI standing for the territory of Malaysia
 s = rui.Rui()
-w = ATuple(s, ruia=a)
-print_ATuple(w)
+w = ANTuple(s, ruia=a)
+print_ANTuple(w)
 
 # let tr2 be interval over which kuala lumpur has been part of Malaysia
 tr2 = rui.Rui()
-j = ATuple(tr2, ruia=a)
+j = ANTuple(tr2, ruia=a)
 NtoNTuple = NtoNTuple(polarity=True, r="part of", p=[x, s], tr=rui.TempRef())
 print_NtoNTuple_tuple(NtoNTuple)

--- a/tests/test_tuple_factory.py
+++ b/tests/test_tuple_factory.py
@@ -1,6 +1,6 @@
 from rt_core_v2.ids_codes.rui import Rui, TempRef
 from rt_core_v2.rttuple import (
-    ATuple,
+    ANTuple,
     DTuple,
     FTuple,
     NtoNTuple,
@@ -43,9 +43,9 @@ data = "data insert"
 
 #TODO Fill out tests for tuple factory usage
 def test_atuple_factory():
-    a = ATuple(ruit, ruia, ruin, ar, unique, time_1)
+    a = ANTuple(ruit, ruia, ruin, ar, unique, time_1)
     # a_args = {TupleComponents.ruit:ruit, TupleComponents.ruit:ruia, TupleComponents.ruit:ruin, TupleComponents.ruit:ar, TupleComponents.ruit:unique, TupleComponents.ruit:time_1}
-    # a_fac, d_fac = insert_rttuple({:ruit, :ruia, :ruin, :ar, :unique, :time_1}, TupleType.ATuple)
+    # a_fac, d_fac = insert_rttuple({:ruit, :ruia, :ruin, :ar, :unique, :time_1}, TupleType.ANTuple)
 # def test_dtuple_factory():
 
 # def test_ftuple_factory():

--- a/tests/test_tuple_factory.py
+++ b/tests/test_tuple_factory.py
@@ -1,7 +1,8 @@
 from rt_core_v2.ids_codes.rui import Rui, TempRef
 from rt_core_v2.rttuple import (
     ANTuple,
-    DTuple,
+    DiTuple,
+    DcTuple,
     FTuple,
     NtoNTuple,
     NtoRTuple,

--- a/tests/test_tuple_factory.py
+++ b/tests/test_tuple_factory.py
@@ -42,7 +42,7 @@ data = "data insert"
 
 
 #TODO Fill out tests for tuple factory usage
-def test_atuple_factory():
+def test_antuple_factory():
     a = ANTuple(ruit, ruia, ruin, ar, unique, time_1)
     # a_args = {TupleComponents.ruit:ruit, TupleComponents.ruit:ruia, TupleComponents.ruit:ruin, TupleComponents.ruit:ar, TupleComponents.ruit:unique, TupleComponents.ruit:time_1}
     # a_fac, d_fac = insert_rttuple({:ruit, :ruia, :ruin, :ar, :unique, :time_1}, TupleType.ANTuple)


### PR DESCRIPTION
Major Changes:
- Split the ATuple class into ANTuple and ARTuple classes that represent ATuples for non-repeatable and repeatable PoR respectively
- Split the DTuple class into DITuple and DCTuple classes that represent the class of DTuples that are for the insertion of another tuple and DTuples that are for changing the status of an already existing tuple by either invalidating or revalidating a tuple
- Moved ruia and ta entries into DITuple, as every tuple has an author and a time of authorship whether or not tuples had an entry for them previously
- Removed redundant entries from the FTuple class that are now stored in DITuples

Minor Changes:
- Changed the template factory method for creating an ATuple to creating am ANTuple
- Changed references to the ATuple and DTuple classes to reference newer versions
- Added a dependency to pyproject.toml, so the project can be imported locally in a different repository
- Converted JSON formatting to a visitor style to be inline with the design paradigm 