### PR TITLE
NtoDE Tuple Data Field Corrected to Use Bytes

### DIFF
--- a/src/rt_core_v2/formatter.py
+++ b/src/rt_core_v2/formatter.py
@@ -3,6 +3,7 @@ import enum
 from io import StringIO
 from uuid import UUID
 from datetime import datetime
+import base64
 
 from rt_core_v2.rttuple import (
     RtTuple,
@@ -33,6 +34,9 @@ class RtTupleJSONEncoder(json.JSONEncoder):
             return str(obj)
         if any(isinstance(obj, cls) for cls in self.val_classes):
             return obj.value
+        if isinstance(obj, bytes):
+            return base64.b64encode(obj).decode('utf-8')
+
         else:
             super().default(obj)
 
@@ -103,6 +107,10 @@ class JsonEntryConverter:
     @staticmethod
     def str_to_relation(relation_str: str) -> Relationship:
         return Relationship(relation_str)
+    
+    @staticmethod
+    def str_to_bytes(x: str):
+        return base64.b64decode(x)
 
 
 
@@ -130,9 +138,8 @@ json_entry_converter = {
     TupleComponents.C: lambda x: float(x),
     TupleComponents.polarity: lambda x: bool(x),
     TupleComponents.r: JsonEntryConverter.str_to_rui,
-    # TODO Figure out the types of code and data
     TupleComponents.code: JsonEntryConverter.str_to_str,
-    TupleComponents.data: JsonEntryConverter.str_to_str,
+    TupleComponents.data: JsonEntryConverter.str_to_bytes,
     TupleComponents.type: lambda x: TupleType(x),
 }
 

--- a/src/rt_core_v2/rttuple.py
+++ b/src/rt_core_v2/rttuple.py
@@ -317,7 +317,7 @@ class NtoDETuple(RtTuple):
     tuple_type: ClassVar[TupleType] = TupleType.NtoDE
     polarity: bool = True
     ruin: Rui = field(default_factory=Rui)
-    data: str =""
+    data: bytes = b''
     ruidt: Rui = field(default_factory=Rui)
 
 @dataclass(eq=False)

--- a/src/rt_core_v2/rttuple.py
+++ b/src/rt_core_v2/rttuple.py
@@ -291,7 +291,6 @@ class NtoCTuple(RtTuple):
     ruin: Rui = field(default_factory=Rui)
     code: str = ""
     tr: TempRef = field(default_factory=TempRef)
-    # TODO Make creating a tempref create an underlying time instance
 
 
 # We use NtoDE instead of NtoI, and we use an instance for the identifying descriptor

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -16,7 +16,7 @@ from rt_core_v2.rttuple import (
 )
 from rt_core_v2.formatter import format_rttuple, json_to_rttuple
 from rt_core_v2.metadata import TupleEventType, RtChangeReason
-
+import base64
 
 def ordered(obj):
     if isinstance(obj, dict):
@@ -49,7 +49,8 @@ polarity = False
 relation = Rui()
 p_list = [ruid, ruin]
 code = "code insert"
-data = "data insert"
+data_original = "data insert"
+data = data_original.encode('utf-8')
 
 """Converts the list into a json appropriate representation"""
 
@@ -205,8 +206,7 @@ def test_ntoc_json():
 def test_ntode_json():
     ntode = NtoDETuple(rui=rui, polarity=polarity, ruin=ruin, data=data, ruidt=ruidt)
     formatted_ntode = format_rttuple(ntode)
-    expected_ntode = f'{{"rui": "{rui}", "tuple_type": "{ntode.tuple_type}", "polarity": {str(polarity).lower()}, "ruin": "{ruin}", "ruidt": "{ruidt}", "data": "{data}"}}'
-
+    expected_ntode = f'{{"rui": "{rui}", "tuple_type": "{ntode.tuple_type}", "polarity": {str(polarity).lower()}, "ruin": "{ruin}", "ruidt": "{ruidt}", "data": "{base64.b64encode(data).decode('utf-8')}"}}'
     print("Ntoctuple Expected:  \n" + expected_ntode)
     print("Ntoctuple Processed:  \n" + formatted_ntode)
 


### PR DESCRIPTION
The only general change was converting the NtoDE Tuple data field into a bytes object. This required making changes in both the class itself, the tuple parsing into and from JSONs, and the JSON tests. 

When converting to JSON, the bytes are converted to a base64 string, as you cannot store the bytes directly in a JSON. 